### PR TITLE
Feature/corect transfer costs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 
 install:
   - pip install --upgrade pip
+  - pip install https://github.com/anguswilliams91/bpl/archive/master.zip
   - pip install .
 
 script:

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -22,6 +22,7 @@ class FPLDataFetcher(object):
         self.current_team_data = None
         self.player_gameweek_data = {}
         self.fpl_team_history_data = None
+        self.fpl_transfer_history_data = None
         self.fpl_league_data = None
         self.fpl_team_data = {} # players in squad, by gameweek
         self.fixture_data = None
@@ -87,7 +88,6 @@ class FPLDataFetcher(object):
         return team_data['picks']
 
 
-
     def get_fpl_team_history_data(self, team_id=None):
         """
         Use our team id to get history data from the FPL API.
@@ -104,6 +104,24 @@ class FPLDataFetcher(object):
                 return None
             self.fpl_team_history_data = json.loads(r.content.decode("utf-8"))
         return self.fpl_team_history_data
+
+
+    def get_fpl_transfer_data(self):
+        """
+        Get our transfer history from the FPL API.
+        """
+        ## return cached value if we already retrieved it.
+        if self.fpl_transfer_history_data:
+            return self.fpl_transfer_history_data
+        ## or get it from the API.
+        url = self.FPL_TEAM_TRANSFER_URL.format(self.FPL_TEAM_ID)
+        r=requests.get(url)
+        if not r.status_code == 200:
+            print("Unable to access FPL transfer history API")
+            return None
+        self.fpl_transfer_history_data = json.loads(r.content.decode("utf-8"))['history']
+        return self.fpl_transfer_history_data
+
 
     def get_fpl_league_data(self):
         """

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -41,6 +41,7 @@ class FPLDataFetcher(object):
         self.FPL_DETAIL_URL = "https://fantasy.premierleague.com/drf/element-summary"
         self.FPL_HISTORY_URL = "https://fantasy.premierleague.com/drf/entry/{}/history"
         self.FPL_TEAM_URL = "https://fantasy.premierleague.com/drf/entry/{}/event/{}/picks"
+        self.FPL_TEAM_TRANSFER_URL = "https://fantasy.premierleague.com/drf/entry/{}/transfers"
         self.FPL_LEAGUE_URL = "https://fantasy.premierleague.com/drf/leagues-classic-standings/{}?phase=1&le-page=1&ls-page=1".format(
             self.FPL_LEAGUE_ID
         )

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -387,8 +387,8 @@ def make_new_team(budget, num_iterations, tag,
     return best_team
 
 
-def apply_strategy(strat, exhaustive_double_transfer,
-                   tag, baseline_dict=None, num_iter=1,
+def apply_strategy(strat, tag,
+                   baseline_dict=None, num_iter=1,
                    update_func_and_args=None,
                    budget=None,
                    verbose=False):
@@ -431,7 +431,7 @@ def apply_strategy(strat, exhaustive_double_transfer,
                 gw_range,
                 update_func_and_args=update_func_and_args
             )
-        elif strat[0][gw] == 2 and exhaustive_double_transfer:
+        elif strat[0][gw] == 2:
             ## two transfers - choose optimum
             new_team, rp, ap = make_optimum_double_transfer(
                 new_team,

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -27,11 +27,15 @@ def generate_transfer_strategies(gw_ahead, free_transfers=1, max_total_hit=None,
     with the total points hit.
     i.e. return value is a list of tuples:
         [({gw:ntransfer, ...},points_hit), ... ]
-    If allow_wildcard is True, we allow the possibility of 0,1,'W' transfers per gw, with 'W' only allowed once.
+
+    If allow_wildcard OR allow_free_hit is True, we allow the possibility of 0,1,'W'/'F' transfers per gw,
+    with each of 'W'/'F' only allowed once.
+    We also don't allow "F" then "W" in consecutive gameweeks, as this is redundant with "W" then "F".
+
     """
     next_gw = get_next_gameweek()
     strategy_list = []
-    if (not allow_wildcard) and (not allow_free_hit) :
+    if not (allow_wildcard or allow_free_hit) :
         possibilities = list(range(4)) if free_transfers > 1 else list(range(3))
         strategies = [
             ({next_gw: i}, 4 * (max(0, i - (1 + int(free_transfers > 1)))))
@@ -58,9 +62,10 @@ def generate_transfer_strategies(gw_ahead, free_transfers=1, max_total_hit=None,
                 already_used_wildcard = "W" in s[0].values()
                 already_used_free_hit = "F" in s[0].values()
                 possibilities = [0,1]
-                if not already_used_wildcard:
+                if allow_wildcard and (not already_used_wildcard) \
+                   and (not s[0][gw-1]=="F"):
                     possibilities.append("W")
-                if not already_used_free_hit:
+                if allow_free_hit and not already_used_free_hit:
                     possibilities.append("F")
             hit_so_far = s[1]
             for p in possibilities:
@@ -313,7 +318,8 @@ def make_new_team(budget, num_iterations, tag,
                   gw_range,
                   season=CURRENT_SEASON,
                   session=None,
-                  update_func_and_args=None):
+                  update_func_and_args=None,
+                  verbose=False):
     """
     Make a team from scratch, i.e. for gameweek 1, or for wildcard, or free hit.
     """
@@ -379,11 +385,11 @@ def make_new_team(budget, num_iterations, tag,
         if score > best_score:
             best_score = score
             best_team = t
-        print(t)
-        print("Score {}".format(score))
-    print("====================================\n")
-    print(best_team)
-    print(best_score)
+
+    if verbose:
+        print("====================================\n")
+        print(best_team)
+        print(best_score)
     return best_team
 
 
@@ -417,11 +423,22 @@ def apply_strategy(strat, tag,
         "points_per_gw": {},
         "players_in": {},
         "players_out": {},
+        "cards_played": {}
     }
     new_team = copy.deepcopy(starting_team)
-
+    ## If we use "free hit" card, we need to remember the team from the week before it
+    team_before_free_hit = None
     for igw, gw in enumerate(gameweeks):
+        ## how many gameweeks ahead should we look at for the purpose of estimating points?
         gw_range = gameweeks[igw:]  # range of gameweeks to end of window
+
+        ## if we used a free hit in the previous gw, we will have stored the previous team, so
+        ## we go back to that one now.
+        if team_before_free_hit:
+            new_team = copy.deepcopy(team_before_free_hit)
+            team_before_free_hit = None
+
+        ## process this gameweek
         if strat[0][gw] == 0:  # no transfers that gameweek
             rp, ap = [], []  ## lists of removed-players, added-players
         elif strat[0][gw] == 1:  # one transfer - choose optimum
@@ -445,6 +462,17 @@ def apply_strategy(strat, tag,
             new_team = make_new_team(budget, num_iter, tag, gw_range,
                                      update_func_and_args=update_func_and_args)
             ap = [p.player_id for p in new_team.players]
+
+        elif strat[0][gw] == "F":   ## free hit - a whole new team!
+            ## remember the starting team (so we can revert to it later)
+            team_before_free_hit = copy.deepcopy(new_team)
+            ## now make a new team for this gw, as is done for wildcard
+            rp = [p.player_id for p in new_team.players]
+            budget = get_team_value(new_team)
+            new_team = make_new_team(budget, num_iter, tag, gw_range,
+                                     update_func_and_args=update_func_and_args)
+            ap = [p.player_id for p in new_team.players]
+
         else:  # choose randomly
             new_team, rp, ap = make_random_transfers(
                 new_team, tag, strat[0][gw], gw_range,
@@ -457,6 +485,8 @@ def apply_strategy(strat, tag,
         if baseline_dict and baseline_dict[gw] - strategy_output["total_score"] > 5:
             break
         strategy_output["points_per_gw"][gw] = score
+        ## record whether we're playing wildcard or free hit this gameweek
+        strategy_output["cards_played"][gw] = strat[0][gw] if isinstance(strat[0][gw],str) else None
         strategy_output["players_in"][gw] = ap
         strategy_output["players_out"][gw] = rp
         ## end of loop over gameweeks

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -147,6 +147,7 @@ class Transaction(Base):
     tag = Column(String(100), nullable=False)
     price = Column(Integer, nullable=False)
 
+
 class TransferSuggestion(Base):
     __tablename__ = "transfer_suggestion"
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -145,6 +145,7 @@ class Transaction(Base):
     bought_or_sold = Column(Integer, nullable=False)  # +1 for bought, -1 for sold
     season = Column(String(100), nullable=False)
     tag = Column(String(100), nullable=False)
+    price = Column(Integer, nullable=False)
 
 class TransferSuggestion(Base):
     __tablename__ = "transfer_suggestion"

--- a/airsenal/scripts/fill_db_init.py
+++ b/airsenal/scripts/fill_db_init.py
@@ -4,7 +4,7 @@ from .fill_fixture_table import  make_fixture_table
 from .fill_result_table import  make_result_table
 from .fill_playerscore_table import make_playerscore_table
 from .fill_fifa_ratings_table import make_fifa_ratings_table
-from .fill_transaction_table import make_transaction_table
+from .fill_transaction_table import fill_initial_team
 from .fill_predictedscore_table import make_predictedscore_table
 
 from ..framework.schema import session_scope
@@ -14,7 +14,7 @@ def main():
 
     with session_scope() as session:
         make_player_table(session)
-        make_transaction_table(session)
+        fill_initial_team(session)
         make_fixture_table(session)
         make_result_table(session)
         make_playerscore_table(session)

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -33,8 +33,8 @@ def count_increments(strategy_string, num_iterations):
     """
     total = 0
     for s in strategy_string:
-        if s=="W":
-            ## wildcard - needs num_iterations iterations
+        if s=="W" or s=="F":
+            ## wildcard or free hit - needs num_iterations iterations
             total+= num_iterations
         elif s=="1":
             ## single transfer - 15 increments (replace each player in turn)
@@ -113,6 +113,7 @@ def print_strat(strat):
     print(" ===============================================")
     for gw in gameweeks_as_int:
         print("\n =========== Gameweek {} ================\n".format(gw))
+        print("Cards played:  {}\n".format(strat['cards_played'][str(gw)]))
         print("Players in:\t\t\tPlayers out:")
         print("-----------\t\t\t------------")
         for i in range(len(strat['players_in'][str(gw)])):

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -109,7 +109,47 @@ def find_best_strat_from_json(tag):
 
 
 def print_strat(strat):
+    """
+    nicely formated printout as output of optimization.
+    """
+
+    gameweeks_as_str = strat['points_per_gw'].keys()
+    gameweeks_as_int = sorted([ int(gw) for gw in gameweeks_as_str])
+    print(" ===============================================")
+    print(" ========= Optimum strategy ====================")
+    print(" ===============================================")
+    for gw in gameweeks_as_int:
+        print("\n =========== Gameweek {} ================\n".format(gw))
+        print("Players in:\t\t\tPlayers out:")
+        print("-----------\t\t\t------------")
+        for i in range(len(strat['players_in'][str(gw)])):
+            pin = get_player_name(strat['players_in'][str(gw)][i])
+            pout = get_player_name(strat['players_out'][str(gw)][i])
+            if len(pin) < 20:
+                subs = "{}\t\t\t{}".format(pin,pout)
+            else:
+                subs = "{}\t\t{}".format(pin,pout)
+            print(subs)
+    print("\n==========================")
+    print(" Total score: {} \n".format(int(strat['total_score'])))
     pass
+
+
+def print_team_for_next_gw(strat):
+    """
+    Display the team (inc. subs and captain) for the next gameweek
+    """
+    t = get_starting_team()
+    gameweeks_as_str = strat['points_per_gw'].keys()
+    gameweeks_as_int = sorted([ int(gw) for gw in gameweeks_as_str])
+    next_gw = gameweeks_as_int[0]
+    for pidout in strat['players_out'][str(next_gw)]:
+        t.remove_player(pidout)
+    for pidin in strat['players_in'][str(next_gw)]:
+        t.add_player(pidin)
+    tag = get_latest_prediction_tag()
+    expected_points = t.get_expected_points(next_gw,tag)
+    print(t)
 
 
 def main():
@@ -129,6 +169,9 @@ def main():
                         action="store_true")
     parser.add_argument("--allow_wildcard",
                         help="include possibility of wildcarding in one of the weeks",
+                        action="store_true")
+    parser.add_argument("--allow_free_hit",
+                        help="include possibility of playing free hit in one of the weeks",
                         action="store_true")
     parser.add_argument("--max_points_hit",
                         help="how many points are we prepared to lose on transfers",
@@ -154,6 +197,10 @@ def main():
         wildcard = True
     else:
         wildcard = False
+    if args.allow_free_hit:
+        free_hit = True
+    else:
+        free_hit = False
     num_free_transfers = args.num_free_transfers
     budget =  args.bank
     max_points_hit = args.max_points_hit
@@ -238,5 +285,5 @@ def main():
     print("\n====================================\n")
     print("Baseline score: {}".format(baseline_score))
     print("Best score: {}".format(best_strategy["total_score"]))
-    print(" best strategy")
-    print(best_strategy)
+    print_strat(best_strategy)
+    print_team_for_next_gw(best_strategy)

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -230,7 +230,7 @@ def main():
     ### generate the list of transfer strategies
     strategies = generate_transfer_strategies(num_weeks_ahead,
                                               num_free_transfers, max_points_hit,
-                                              wildcard)
+                                              wildcard,free_hit)
     ## define overall progress bar
     total_progress = tqdm(total=len(strategies), desc="Total progress")
 

--- a/airsenal/scripts/update_results_db.py
+++ b/airsenal/scripts/update_results_db.py
@@ -12,7 +12,7 @@ import argparse
 
 from .fill_result_table import  fill_results_from_api
 from .fill_playerscore_table import fill_playerscores_from_api
-from .fill_transaction_table import add_transaction
+from .fill_transaction_table import update_team
 from ..framework.utils import *
 from ..framework.schema import session_scope
 
@@ -43,13 +43,11 @@ def main():
         db_players = sorted(get_current_players(season=season,dbsession=session))
         api_players = sorted(get_players_for_gameweek(last_finished))
         if db_players != api_players:
-            players_out = list(set(db_players).difference(api_players))
-            players_in = list(set(api_players).difference(db_players))
-            for p in players_out:
-                add_transaction(p, last_finished, -1, season, tag, session,
-                                os.path.join(os.path.dirname(__file__), "../data/transactions.csv"))
-            for p in players_in:
-                add_transaction(p, last_finished, 1, season, tag, session,
-                                os.path.join(os.path.dirname(__file__), "../data/transactions.csv"))
+            update_team(season=season, session=session)
         else:
             print("Team is up-to-date")
+
+
+if __name__ == "__main__":
+    print(" ==== updating results and transactions === ")
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["cython", "numpy", "pystan"]
+requires = ["cython", "numpy", "pystan","setuptools"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 with open("requirements.txt", "r") as f:
     REQUIRED_PACKAGES = f.read().splitlines()
-REQUIRED_PACKAGES.append("bpl==v0.0.1")
+#REQUIRED_PACKAGES.append("bpl==v0.0.1")
 
 
 setup(
@@ -19,7 +19,7 @@ setup(
               "airsenal.scripts"],
     install_requires=REQUIRED_PACKAGES,
     setup_requires=REQUIRED_PACKAGES,
-    dependency_links=["https://github.com/anguswilliams91/bpl/archive/v0.0.1-alpha.zip#egg=bpl-v0.0.1"],
+    dependency_links=["https://github.com/anguswilliams91/bpl/archive/v0.0.1-alpha.zip#egg=bpl"],
     entry_points={"console_scripts": [
         "setup_airsenal_database=airsenal.scripts.fill_db_init:main",
         "update_airsenal_database=airsenal.scripts.update_results_db:main",


### PR DESCRIPTION
* Add new field "price" to Transaction table in DB.
* Use transfers API to get information on all transfers in/out with the correct prices.
* Revise fill_transaction_table to give separate methods to fill initial team, and to add more recent transactions.
* Update get_starting_team to use the full transactions table.
* Update apply_strategy to use budget based on current  team value plus (now correct) money in the bank.
* In Team.add_player allow the budget and team constraints to be skipped (as individual transfers in past gameweeks may have violated them, as long as the team at the end of all transfers that gw obeyed them).