### PR TITLE
Fix FPL API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ pip install .
 
 ## Getting started
 
-Once you've installed the module, you will need to set three environment variables (or alternatively you can put the values into files in the ```airsenal/data/``` directory, e.g. ```airsenal/data/FPL_TEAM_ID```:
+Once you've installed the module, you will need to set five environment variables (or alternatively you can put the values into files in the ```airsenal/data/``` directory, e.g. ```airsenal/data/FPL_TEAM_ID```:
 
 1. `FD_API_KEY`: an API key for [football data](https://www.football-data.org/) (this is only needed for filling past seasons results if not already present as a csv file in the ```data/``` directory.)
 2. `FPL_TEAM_ID`: the team ID for your FPL side.
 3. `FPL_LEAGUE_ID`: a league ID for FPL (this is only required for a small subset of functionality).
+4. `FPL_LOGIN`: your FPL login, usually email (this is only required to get league standings)
+5. `FPL_PASSWORD`: your FPL password (this is only required to get league standings)
 
 Once this is done, run the following command
 

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -34,7 +34,8 @@ def get_result_df(session):
     df_past["home_goals"] = df_past["home_goals"].astype(int)
     df_past["away_goals"] = df_past["away_goals"].astype(int)
     df_past["date"] = pd.to_datetime(df_past["date"])
-    df_past = df_past[df_past["date"] > pd.to_datetime("2016-08-01")]
+
+    #df_past = df_past[df_past["date"] > pd.to_datetime("2016-08-01")]
     return df_past
 
 

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -34,7 +34,7 @@ def get_result_df(session):
     df_past["home_goals"] = df_past["home_goals"].astype(int)
     df_past["away_goals"] = df_past["away_goals"].astype(int)
     df_past["date"] = pd.to_datetime(df_past["date"])
-    df_past = df_past[df_past["date"] > "2016-08-01"]
+    df_past = df_past[df_past["date"] > pd.to_datetime("2016-08-01")]
     return df_past
 
 

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -35,7 +35,6 @@ def get_result_df(session):
     df_past["away_goals"] = df_past["away_goals"].astype(int)
     df_past["date"] = pd.to_datetime(df_past["date"])
 
-    #df_past = df_past[df_past["date"] > pd.to_datetime("2016-08-01")]
     return df_past
 
 

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -39,11 +39,11 @@ class FPLDataFetcher(object):
             else:
                 print("Couldn't find {} - some data may be unavailable".format(ID))
                 self.__setattr__(ID, "MISSING_ID")
-        self.FPL_SUMMARY_API_URL = "https://fantasy.premierleague.com/api/bootstrap-static"
-        self.FPL_DETAIL_URL = "https://fantasy.premierleague.com/api/element-summary"
-        self.FPL_HISTORY_URL = "https://fantasy.premierleague.com/api/entry/{}/history"
-        self.FPL_TEAM_URL = "https://fantasy.premierleague.com/api/entry/{}/event/{}/picks"
-        self.FPL_TEAM_TRANSFER_URL = "https://fantasy.premierleague.com/api/entry/{}/transfers"
+        self.FPL_SUMMARY_API_URL = "https://fantasy.premierleague.com/api/bootstrap-static/"
+        self.FPL_DETAIL_URL = "https://fantasy.premierleague.com/api/element-summary/{}/"
+        self.FPL_HISTORY_URL = "https://fantasy.premierleague.com/api/entry/{}/history/"
+        self.FPL_TEAM_URL = "https://fantasy.premierleague.com/api/entry/{}/event/{}/picks/"
+        self.FPL_TEAM_TRANSFER_URL = "https://fantasy.premierleague.com/api/entry/{}/transfers/"
         self.FPL_LEAGUE_URL = "https://fantasy.premierleague.com/api/leagues-classic-standings/{}?phase=1&le-page=1&ls-page=1".format(
             self.FPL_LEAGUE_ID
         )
@@ -195,7 +195,7 @@ class FPLDataFetcher(object):
                 not gameweek in self.player_gameweek_data[player_id].keys()
             ):
 
-                r = requests.get("{}/{}".format(self.FPL_DETAIL_URL, player_id))
+                r = requests.get(self.FPL_DETAIL_URL.format(player_id))
                 if not r.status_code == 200:
                     print("Error retrieving data for player {}".format(player_id))
                     return []

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -28,7 +28,9 @@ class FPLDataFetcher(object):
         self.fpl_team_data = {} # players in squad, by gameweek
         self.fixture_data = None
         for ID in ["FPL_LEAGUE_ID",
-                   "FPL_TEAM_ID"]:
+                   "FPL_TEAM_ID",
+                   "FPL_LOGIN",
+                   "FPL_PASSWORD"]:
             if ID in os.environ.keys():
                 self.__setattr__(ID, os.environ[ID])
             elif os.path.exists(os.path.join(os.path.dirname(__file__), "../data/{}".format(ID))):
@@ -44,7 +46,7 @@ class FPLDataFetcher(object):
         self.FPL_HISTORY_URL = "https://fantasy.premierleague.com/api/entry/{}/history/"
         self.FPL_TEAM_URL = "https://fantasy.premierleague.com/api/entry/{}/event/{}/picks/"
         self.FPL_TEAM_TRANSFER_URL = "https://fantasy.premierleague.com/api/entry/{}/transfers/"
-        self.FPL_LEAGUE_URL = "https://fantasy.premierleague.com/api/leagues-classic-standings/{}?phase=1&le-page=1&ls-page=1".format(
+        self.FPL_LEAGUE_URL = "https://fantasy.premierleague.com/api/leagues-classic/{}/standings/?page_new_entries=1&page_standings=1".format(
             self.FPL_LEAGUE_ID
         )
         self.FPL_FIXTURE_URL = "https://fantasy.premierleague.com/api/fixtures/"
@@ -131,7 +133,11 @@ class FPLDataFetcher(object):
         if self.fpl_league_data:
             return self.fpl_league_data
         else:
-            r = requests.get(self.FPL_LEAGUE_URL)
+            headers = {"login": self.FPL_LOGIN,
+                       "password": self.FPL_PASSWORD,
+                       "app": "plfpl-web",
+                       "redirect_uri": "https://fantasy.premierleague.com/"}
+            r = requests.get(self.FPL_LEAGUE_URL, headers=headers)
             if not r.status_code == 200:
                 print("Unable to access FPL league API")
                 return None

--- a/airsenal/scripts/fill_db_init.py
+++ b/airsenal/scripts/fill_db_init.py
@@ -14,7 +14,7 @@ def main():
 
     with session_scope() as session:
         make_player_table(session)
-       ## fill_initial_team(session)
+        fill_initial_team(session)
         make_fixture_table(session)
         make_result_table(session)
         make_playerscore_table(session)


### PR DESCRIPTION
Implements changes to FPL API URLs. 

Please verify that `setup_airsenal_database`, `update_airsenal_database`, `run_airsenal_predictions` and `run_airsenal_optimization` work for you after these changes (and that they give you errors with the current master).

@nbarlowATI I have also commented line 38 of `airsenal/framework/bpl_interface.py`, which was:
`df_past = df_past[df_past["date"] > "2016-08-01"`
This was throwing a type comparison error between string and datetime. Do you know why this was in there and was it needed (and if it is needed does the date need to be updated)?

Closes #69 