### PR TITLE
Fix get_recent_minutes_for_player

### DIFF
--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -583,7 +583,15 @@ def get_recent_minutes_for_player(player,
     ## for speed, we use the fact that matches from this season
     ## are uploaded in order, so we can just take the last n
     ## rows, no need to look up dates and sort.
-    return [r.minutes for r in rows[-num_match_to_use:]]
+    minutes = [r.minutes for r in rows[-num_match_to_use:]]
+    
+    # if going back num_matches_to_use from last_gw takes us before the start
+    # of the season, also include a minutes estimate using last season's data
+    if first_gw < 0 or len(minutes) == 0:
+        minutes = (minutes +
+                   estimate_minutes_from_prev_season(player, season, dbsession))
+        
+    return minutes
 
 
 def get_last_gameweek_in_db(season=CURRENT_SEASON, dbsession=None):

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -577,8 +577,8 @@ def get_recent_minutes_for_player(player,
     rows = dbsession.query(PlayerScore)\
                   .filter(PlayerScore.fixture.has(season=season))\
                   .filter_by(player_id=player.player_id)\
-                  .filter(PlayerScore.fixture.has(Fixture.gameweek >= first_gw))\
-                  .filter(PlayerScore.fixture.has(Fixture.gameweek < last_gw))\
+                  .filter(PlayerScore.fixture.has(Fixture.gameweek > first_gw))\
+                  .filter(PlayerScore.fixture.has(Fixture.gameweek <= last_gw))\
                   .all()
     ## for speed, we use the fact that matches from this season
     ## are uploaded in order, so we can just take the last n


### PR DESCRIPTION
Closes #71 

This fixes the bug with expected points I believe, though we may want to make further improvements (for this week only minutes played in GW1 will be used for predicting future minutes, might want to fold in last season's average minutes as well). See #71 for details. 

I'm running the calculations now so will have new results in the morning 🙂  