### PR TITLE
Simplify install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
 
 install:
   - pip install --upgrade pip
-  - pip install https://github.com/anguswilliams91/bpl/archive/master.zip
   - pip install .
 
 script:

--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ It is recommended that you use a conda or virtualenv environment to install and 
 The Stan model used to predict match results is in the package https://github.com/anguswilliams91/bpl, and to run this you will need a working (recent) C++ compiler.
 An example setup could be:
 ```
-conda create -n airsenalenv python=3.7 pystan=2.18.0.0
+conda create -n airsenalenv python=3.7
 conda activate airsenalenv
-conda install -c psi4 gcc-5
-pip install https://github.com/anguswilliams91/bpl/archive/master.zip
+conda install -c psi4 gcc-5 # necessary if you don't have an up-to-date C++ compiler on your system 
 git clone https://github.com/alan-turing-institute/AIrsenal.git
 cd AIrsenal
 pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ bs4
 selenium
 boto3
 pip
-pystan
+bpl==0.0.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup
 
 with open("requirements.txt", "r") as f:
     REQUIRED_PACKAGES = f.read().splitlines()
-#REQUIRED_PACKAGES.append("bpl==v0.0.1")
 
 
 setup(
@@ -18,8 +17,6 @@ setup(
               "airsenal.scraper",
               "airsenal.scripts"],
     install_requires=REQUIRED_PACKAGES,
-    setup_requires=REQUIRED_PACKAGES,
-    dependency_links=["https://github.com/anguswilliams91/bpl/archive/v0.0.1-alpha.zip#egg=bpl"],
     entry_points={"console_scripts": [
         "setup_airsenal_database=airsenal.scripts.fill_db_init:main",
         "update_airsenal_database=airsenal.scripts.update_results_db:main",


### PR DESCRIPTION
I've put `bpl` on pypi now, so I have simplified the installation of airsenal as a consequence. I also modified the travis config to run the tests on 3.7 as well as 3.6.