### PR TITLE
add method to calculate player sale price

### DIFF
--- a/airsenal/framework/team.py
+++ b/airsenal/framework/team.py
@@ -7,7 +7,7 @@ from operator import itemgetter
 from math import floor
 
 from .player import CandidatePlayer, Player, CURRENT_SEASON
-from .utils import get_player
+from .utils import get_player, get_sell_price_for_player
 
 # how many players do we need to add
 TOTAL_PER_POSITION = {"GK": 2, "DEF": 5, "MID": 5, "FWD": 3}
@@ -124,7 +124,6 @@ class Team(object):
         self.budget -= player.current_price
         return True
 
-
     def remove_player(self, player_id, price=None):
         """
         Remove player from our list.
@@ -137,37 +136,11 @@ class Team(object):
                 if price:
                     self.budget += price
                 else:
-                    self.budget += self.get_sale_price(p.player_id)
+                    self.budget += get_sell_price_for_player(p.player_id)
                 self.num_position[p.position] -= 1
                 self.players.remove(p)
                 return True
         return False
-
-    def get_sale_price(self, player_id):
-        """Get the sale price for a player based on difference between
-        player's team price (player's cost when purchased from the transaction
-        table) and the player's current price (from the players table).
-        """
-        # current price for the player in the database players table
-        current_price = get_player(player_id).current_price(CURRENT_SEASON)
-        
-        # price for the player in the team, which originated from transaction
-        # data.
-        for p in self.players:
-            if p.player_id == player_id:
-                purchase_price = p.current_price
-
-                if current_price > purchase_price:
-                    # only get to keep half of a price gain, rounded down
-                    profit = floor(0.5 * (current_price - purchase_price))
-                    return purchase_price + profit
-                else:
-                    # if players price has decreased we just get the current
-                    # price back
-                    return current_price
-        
-        # player not in the team
-        return False     
 
     def check_no_duplicate_player(self, player):
         """


### PR DESCRIPTION
This adds the function `get_sale_price(self, player_id)` to the `Team` class, which calculates the sale price for a player based on the difference between the player's "team" price (i.e. purchase price from the transactions table) and actual current price (i.e. price from the players table in the database).

Intended to fix the problem of unaffordable transfers being suggested, see #113 for more details. It works for me now but I'm not sure how this was meant to be working before - maybe we can have a look together in the hack session on Wednesday @nbarlowATI.

Closes #113