### PR TITLE
Fix calculation of the sale price again

### DIFF
--- a/airsenal/tests/test_team.py
+++ b/airsenal/tests/test_team.py
@@ -110,7 +110,7 @@ def test_remove_player(fill_players):
         t.add_player(1,season=TEST_SEASON,dbsession=ts)
         assert len(t.players) == 1
         assert t.num_position["GK"] == 1
-        t.remove_player(1)
+        t.remove_player(1, use_api=False)
         assert len(t.players) == 0
         assert t.num_position["GK"] == 0
         assert t.budget == 1000


### PR DESCRIPTION
Quick fix that adds a function to calculate the sale price to the team class. To get the current price for a player tries these 3 options (in decreasing order of likelihood of being correct!):
1) The API
2) The Database
3) The purchase price

To get the tests to work I've made using the API optional. Before we had a dummy player with id 1, which corresponds to Mustafi this season so the remove_player budget test wasn't working due to getting Mustafi's price back not the dummy players. We should fix this properly in the future.