### PR TITLE
print players with top predicted points

### DIFF
--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -590,6 +590,41 @@ def get_predicted_points(gameweek, tag, position="all", team="all",
     return output_list
 
 
+def get_top_predicted_points(gameweek=None, tag=None,
+                             position="all", team="all",
+                             n_players=10,
+                             season=CURRENT_SEASON, dbsession=None):
+    """Print players with the top predicted points.
+
+    
+    Keyword Arguments:
+        gameweek {int or list} -- Single gameweek or list of gameweeks in which
+        case returned totals are sums across all gameweeks (default: next
+        gameweek).
+        tag {str} -- Prediction tag to query (default: latest prediction tag)
+        position {str} -- Player position to query (default: {"all"})
+        team {str} -- Team to query (default: {"all"})
+        n_players {int} -- Number of players to return (default: {10})
+        season {str} -- Season to query (default: {CURRENT_SEASON})
+        dbsession {SQLAlchemy session} -- Database session (default: {None})
+    """
+    if not tag:
+        tag = get_latest_prediction_tag()
+    if not gameweek:
+        gameweek = get_next_gameweek()
+        
+    pts = get_predicted_points(gameweek, tag, position=position, team=team,
+                               season=season, dbsession=dbsession)
+    pts = sorted(pts, key=lambda x: x[1], reverse=True)
+    
+    print("="*50)
+    print("PREDICTED TOP {} PLAYERS FOR GAMEWEEK(S) {}:".format(n_players,
+                                                                gameweek))
+    print("="*50)
+    for i, p in enumerate(pts[:n_players]):
+        print("{}. {}, {:.2f}pts".format(i+1, p[0].name, p[1]))
+
+
 def get_return_gameweek_for_player(player_id, dbsession=None):
     """
     If  a player is injured and there is 'news' about them on FPL,

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -592,7 +592,7 @@ def get_predicted_points(gameweek, tag, position="all", team="all",
 
 def get_top_predicted_points(gameweek=None, tag=None,
                              position="all", team="all",
-                             n_players=10,
+                             n_players=10, per_position=False,
                              season=CURRENT_SEASON, dbsession=None):
     """Print players with the top predicted points.
 
@@ -603,6 +603,8 @@ def get_top_predicted_points(gameweek=None, tag=None,
         gameweek).
         tag {str} -- Prediction tag to query (default: latest prediction tag)
         position {str} -- Player position to query (default: {"all"})
+        per_position {boolean} -- If True print top n_players players for
+        each position separately (default: {False})
         team {str} -- Team to query (default: {"all"})
         n_players {int} -- Number of players to return (default: {10})
         season {str} -- Season to query (default: {CURRENT_SEASON})
@@ -612,17 +614,30 @@ def get_top_predicted_points(gameweek=None, tag=None,
         tag = get_latest_prediction_tag()
     if not gameweek:
         gameweek = get_next_gameweek()
-        
-    pts = get_predicted_points(gameweek, tag, position=position, team=team,
-                               season=season, dbsession=dbsession)
-    pts = sorted(pts, key=lambda x: x[1], reverse=True)
     
     print("="*50)
     print("PREDICTED TOP {} PLAYERS FOR GAMEWEEK(S) {}:".format(n_players,
                                                                 gameweek))
     print("="*50)
-    for i, p in enumerate(pts[:n_players]):
-        print("{}. {}, {:.2f}pts".format(i+1, p[0].name, p[1]))
+    
+    if not per_position:
+        pts = get_predicted_points(gameweek, tag, position=position, team=team,
+                                season=season, dbsession=dbsession)
+        pts = sorted(pts, key=lambda x: x[1], reverse=True)
+    
+        for i, p in enumerate(pts[:n_players]):
+            print("{}. {}, {:.2f}pts".format(i+1, p[0].name, p[1]))
+            
+    else:
+        for position in ["GK", "DEF", "MID", "FWD"]:
+            pts = get_predicted_points(gameweek, tag, position=position,
+                                       team=team, season=season,
+                                       dbsession=dbsession)
+            pts = sorted(pts, key=lambda x: x[1], reverse=True)
+            print("{}:".format(position))
+            for i, p in enumerate(pts[:n_players]):
+                print("{}. {}, {:.2f}pts".format(i+1, p[0].name, p[1]))
+            print("-"*25)
 
 
 def get_return_gameweek_for_player(player_id, dbsession=None):

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -157,5 +157,5 @@ def main():
         
         # print players with top predicted points
         get_top_predicted_points(gameweek=gw_range, tag=tag,
-                                 season=args.season, dbsession=session)
-
+                                 season=args.season, dbsession=session,
+                                 per_position=True, n_players=5)


### PR DESCRIPTION
Small change to add a function that prints the players with the top 10 predicted points after doing `run_airsenal_predictions`. Function added is `framework.utils.get_top_predicted_points`.

Output is like this:
```
==================================================
PREDICTED TOP 10 PLAYERS FOR GAMEWEEK(S) [13, 14, 15]:
==================================================
1. Pierre-Emerick Aubameyang, 17.68pts
2. Mohamed Salah, 17.18pts
3. Sadio Mané, 16.38pts
4. Raheem Sterling, 15.52pts
5. Heung-Min Son, 15.48pts
6. Tammy Abraham, 14.76pts
7. Anthony Martial, 14.56pts
8. Alexandre Lacazette, 13.99pts
9. Bamidele Alli, 13.76pts
10. Roberto Firmino, 13.70pts
```