### PR TITLE
[Ready for review] Rename entry points to start with "airsenal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Once you've installed the module, you will need to set some environment variable
 Once this is done, run the following command:
 
 ```shell
-setup_airsenal_database
+airsenal_setup_initial_db
 ```
 
 You should get a file ```/tmp/data.db```.  This will fill the database with all that is needed up to the present day.
@@ -80,7 +80,7 @@ You should get a file ```/tmp/data.db```.  This will fill the database with all 
 You can run sanity checks on the data using the following command:
 
 ```
-check_airsenal_data
+airsenal_check_data
 ```
 
 ## Updating, running predictions and optimization.
@@ -88,17 +88,17 @@ check_airsenal_data
 To stay up to date in the future, you will need to fill three tables: ```match```, ```player_score```, and ```transaction```
 with more recent data, using the command
 ```shell
-update_airsenal_database
+airsenal_update_db
 ```
 
 The next step is to use the team- and player-level Stan models to predict the expected points for all players for the next fixtures.  This is done using the command
 ```shell
-run_airsenal_predictions --weeks_ahead 3
+airsenal_run_prediction --weeks_ahead 3
 ```
 (we normally look 3 weeks ahead, as this is an achievable horizon to run the optimization over, but also because things like form and injuries can change a lot in 3 weeks!)
 
 Finally, we need to run the optimizer to pick the best transfer strategy over the next weeks (and hence the best team for the next week).
 ```shell
-run_airsenal_optimization --weeks_ahead 3
+airsenal_run_optimization --weeks_ahead 3
 ```
 This will take a while, but should eventually provide a printout of the optimal transfer strategy, in addition to the teamsheet for the next match (including who to make captain, and the order of the substitutes).

--- a/airsenal/scripts/run_airsenal_pipeline.sh
+++ b/airsenal/scripts/run_airsenal_pipeline.sh
@@ -58,7 +58,7 @@ rm /tmp/data.db
 
 # Run full AIrsenal pipeline
 # with default arguments but on all cores
-setup_airsenal_database
-update_airsenal_database --noattr
-run_airsenal_predictions --num_thread $NCPU --weeks_ahead $WEEKS_AHEAD
-run_airsenal_optimization --num_thread $NCPU --weeks_ahead $WEEKS_AHEAD --bank $BANK --num_free_transfers $NUM_FREE_TRANSFERS
+airsenal_setup_initial_db
+airsenal_update_db --noattr
+airsenal_run_prediction --num_thread $NCPU --weeks_ahead $WEEKS_AHEAD
+airsenal_run_optimization --num_thread $NCPU --weeks_ahead $WEEKS_AHEAD --bank $BANK --num_free_transfers $NUM_FREE_TRANSFERS

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setup(
     install_requires=REQUIRED_PACKAGES,
 
     entry_points={"console_scripts": [
-        "setup_airsenal_database=airsenal.scripts.fill_db_init:main",
-        "update_airsenal_database=airsenal.scripts.update_results_transactions_db:main",
+        "airsenal_setup_initial_db=airsenal.scripts.fill_db_init:main",
+        "airsenal_update_db=airsenal.scripts.update_results_transactions_db:main",
         "airsenal_plot=airsenal.scripts.plot_league_standings:main",
-        "run_airsenal_predictions=airsenal.scripts.fill_predictedscore_table:main",
-        "run_airsenal_optimization=airsenal.scripts.fill_transfersuggestion_table:main",
+        "airsenal_run_prediction=airsenal.scripts.fill_predictedscore_table:main",
+        "airsenal_run_optimization=airsenal.scripts.fill_transfersuggestion_table:main",
         "airsenal_make_team=airsenal.scripts.team_builder:main",
-        "check_airsenal_data=airsenal.scripts.data_sanity_checks:run_all_checks",
-        "dump_db_contents=airsenal.scripts.dump_db_contents:main"
+        "airsenal_check_data=airsenal.scripts.data_sanity_checks:run_all_checks",
+        "airsenal_dump_db=airsenal.scripts.dump_db_contents:main"
         ],
 
     },


### PR DESCRIPTION
 1. Updated the `entry_points` dict in `setup.py` to match the naming suggested in #202 

- `airsenal_setup_initial_db`
- `airsenal_update_db`
- `airsenal_dump_db`
- `airsenal_check_data`
- `airsenal_make_team`
- `airsenal_run_prediction`
- `airsenal_run_optimization`
- `airsenal_plot`

2. Updated `run_airsenal_pipeline.sh` to match the renaming 
3. Made changes to the `README.md` to match the renamed entry points 

- Closes #202 : Make all entrypoints start with "airsenal" 

@nbarlowATI - I've made the changes that hopefully fix the issue. Would appreciate any feedback since it's my first contribution. I tried to follow the guidelines but feel free to point out if I missed something. 

