### PR TITLE
[#244] Fix missing price for players with blank gameweek 1

### DIFF
--- a/airsenal/framework/transaction_utils.py
+++ b/airsenal/framework/transaction_utils.py
@@ -13,6 +13,7 @@ from .utils import (
     get_past_seasons,
     NEXT_GAMEWEEK,
     CURRENT_SEASON,
+    get_player,
 )
 
 
@@ -44,7 +45,15 @@ def fill_initial_team(session, season=CURRENT_SEASON, tag="AIrsenal" + CURRENT_S
     api_players = get_players_for_gameweek(1)
     for pid in api_players:
         gw1_data = fetcher.get_gameweek_data_for_player(pid, 1)
-        price = gw1_data[0]["value"]
+        if len(gw1_data) == 0:
+            # Edge case where API doesn't have player data for gameweek 1, e.g. in 20/21
+            # season where 4 teams didn't play gameweek 1. Calculate GW1 price from
+            # API using current price and total price change.
+            pdata = fetcher.get_player_summary_data()[pid]
+            price = pdata["now_cost"] - pdata["cost_change_event"]
+        else:
+            price = gw1_data[0]["value"]
+        
         add_transaction(pid, 1, 1, price, season, tag, session)
 
 


### PR DESCRIPTION
FPL API doesn't store any gameweek 1 information for players with blank gameweek 1, which caused filling the initial team in the database to fail if the squad contained any of those players. To determine the gameweek 1 price for those players use the current price and the total price change for the season (both available from the API).