### PR TITLE
Speedup get_player_history_df

### DIFF
--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -125,6 +125,7 @@ def get_player_history_df(
 
     df = pd.concat(df_list)
     df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df.reset_index(drop=True, inplace=True)
     
     return df
 

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -64,7 +64,7 @@ def get_player_history_df(
         "minutes",
         "team_goals",
     ]
-    df = pd.DataFrame(columns=col_names)
+    df_list = []
     players = list_players(
         position=position, season=season, dbsession=session, gameweek=gameweek
     )
@@ -79,6 +79,7 @@ def get_player_history_df(
         )
         results = player.scores
         row_count = 0
+        player_data = []
         for row in results:
             match_id = row.result_id
             if not match_id:
@@ -94,7 +95,7 @@ def get_player_history_df(
             assists = row.assists
             # find the match, in order to get team goals
             match_result = row.result
-            match_date = dateparser.parse(row.fixture.date)
+            match_date = row.fixture.date
             if row.fixture.home_team == row.opponent:
                 team_goals = match_result.away_score
             elif row.fixture.away_team == row.opponent:
@@ -102,7 +103,7 @@ def get_player_history_df(
             else:
                 print("Unknown opponent!")
                 team_goals = -1
-            df.loc[len(df)] = [
+            player_data.append([
                 player.player_id,
                 player.name,
                 match_id,
@@ -111,14 +112,20 @@ def get_player_history_df(
                 assists,
                 minutes,
                 team_goals,
-            ]
+            ])
             row_count += 1
 
         ## fill blank rows so they are all the same size
         if row_count < max_matches_per_player:
-            for i in range(row_count, max_matches_per_player):
-                df.loc[len(df)] = [player.player_id, player.name, 0, 0, 0, 0, 0, 0]
+            player_data += [[
+                player.player_id, player.name, 0, 0, 0, 0, 0, 0
+            ]] * (max_matches_per_player - row_count)
 
+        df_list.append(pd.DataFrame(player_data, columns=col_names))
+
+    df = pd.concat(df_list)
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    
     return df
 
 

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -64,7 +64,7 @@ def get_player_history_df(
         "minutes",
         "team_goals",
     ]
-    df_list = []
+    player_data = []
     players = list_players(
         position=position, season=season, dbsession=session, gameweek=gameweek
     )
@@ -79,7 +79,6 @@ def get_player_history_df(
         )
         results = player.scores
         row_count = 0
-        player_data = []
         for row in results:
             match_id = row.result_id
             if not match_id:
@@ -121,9 +120,7 @@ def get_player_history_df(
                 player.player_id, player.name, 0, 0, 0, 0, 0, 0
             ]] * (max_matches_per_player - row_count)
 
-        df_list.append(pd.DataFrame(player_data, columns=col_names))
-
-    df = pd.concat(df_list)
+    df = pd.DataFrame(player_data, columns=col_names)
     df["date"] = pd.to_datetime(df["date"], errors="coerce")
     df.reset_index(drop=True, inplace=True)
     


### PR DESCRIPTION
Changes the use of pandas in `get_player_history_df`, making that function much faster (only takes a few seconds rather than several minutes). Before these change `airsenal_run_prediction --num_thread 4` takes 7 mins 50 seconds on my laptop, after the changes it takes 4 mins 20 seconds.

Relates to #143 and #169