### PR TITLE
Using environment variables for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python            # this works for Linux but is an error on macOS or Windows
 
+env:
+  global:
+    - FPL_TEAM_ID=208595      # AIrsenal's ID need to change it every year
+
 jobs:
   include:
     - name: "Python 3.7.4 on Xenial Linux"


### PR DESCRIPTION
Issue: #285 

This add should allow forks to run tests correctly. Setting the environment variable in the travis file.
As suggested by: @jack89roberts 

The only drawback is that it use the AIrsenal's ID for running the test and needs to be updated every year. 