### PR TITLE
unpin bpl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tqdm==v4.29.1
+tqdm>=v4.29.1
 black
 pandas
 sqlalchemy
@@ -15,4 +15,4 @@ flask_cors
 flask_session
 jupyter
 seaborn
-click==7.1.2
+click>=7.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scipy
 pip
 pystan>=2.14
 pytest
-bpl==0.0.4
+bpl>=0.1.0
 flask
 flask_cors
 flask_session


### PR DESCRIPTION
I noticed `bpl` was pinned to 0.0.4, but I don't think it's necessary since the API hasn't changed in the latest version (0.1.0). I've updated the requirement from `bpl==0.0.4` to `bpl>=0.1.0`.

Edit - I now see from the commit history that this pin of bpl was me a long time ago! :see_no_evil: 