### PR TITLE
prompt the user for FPL login and password

### DIFF
--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -6,6 +6,7 @@ import os
 import requests
 import json
 import time
+import getpass
 
 
 class FPLDataFetcher(object):
@@ -29,18 +30,17 @@ class FPLDataFetcher(object):
             if ID in os.environ.keys():
                 self.__setattr__(ID, os.environ[ID])
             elif os.path.exists(
-                os.path.join(os.path.dirname(__file__), "../data/{}".format(ID))
+                os.path.join(os.path.dirname(__file__), "..","data","{}".format(ID))
             ):
                 self.__setattr__(
                     ID,
                     open(
-                        os.path.join(os.path.dirname(__file__), "../data/{}".format(ID))
+                        os.path.join(os.path.dirname(__file__), "..","data","{}".format(ID))
                     )
                     .read()
                     .strip(),
                 )
             else:
-                print("Couldn't find {} - some data may be unavailable".format(ID))
                 self.__setattr__(ID, "MISSING_ID")
         self.FPL_SUMMARY_API_URL = (
             "https://fantasy.premierleague.com/api/bootstrap-static/"
@@ -59,6 +59,29 @@ class FPLDataFetcher(object):
             self.FPL_LEAGUE_ID
         )
         self.FPL_FIXTURE_URL = "https://fantasy.premierleague.com/api/fixtures/"
+
+    def get_fpl_credentials(self):
+        """
+        If we didn't have FPL_LOGIN and FPL_PASSWORD available as files in
+        airsenal/data or as environment variables, prompt the user for them.
+        """
+        print(
+            """
+            Accessing FPL mini-league data requires the login (email address) and password for your FPL account.
+            """
+        )
+        self.FPL_LOGIN = input("Please enter FPL login: ")
+        self.FPL_PASSWORD = getpass.getpass("Please enter FPL password: ")
+        data_loc = os.path.join(os.path.dirname(__file__),"..","data")
+        store_credentials = ""
+        while not (store_credentials.lower() == "y" or \
+                   store_credentials.lower() == "n"):
+            store_credentials = input("\nWould you like to store these credentials in {} so that you won't be prompted for them again? (y/n): ".format(data_loc))
+        if store_credentials.lower() == "y":
+            with open(os.path.join(data_loc, "FPL_LOGIN"),"w") as login_file:
+                login_file.write(self.FPL_LOGIN)
+            with open(os.path.join(data_loc, "FPL_PASSWORD"),"w") as passwd_file:
+                passwd_file.write(self.FPL_PASSWORD)
 
     def get_current_summary_data(self):
         """
@@ -142,7 +165,12 @@ class FPLDataFetcher(object):
         else:
             session = requests.session()
             url = "https://users.premierleague.com/accounts/login/"
-
+            print("FPL credentials {} {}".format(self.FPL_LOGIN, self.FPL_PASSWORD))
+            if (not self.FPL_LOGIN) or (not self.FPL_PASSWORD) or \
+                self.FPL_LOGIN == "MISSING_ID" or \
+                self.FPL_PASSWORD == "MISSING_ID":
+                # prompt the user for credentials
+                self.get_fpl_credentials()
             headers = {
                 "login": self.FPL_LOGIN,
                 "password": self.FPL_PASSWORD,


### PR DESCRIPTION
If FPL_LOGIN and FPL_PASSWORD are not found in `airsenal/data/` files or environment variables, prompt the user for them when accessing mini-league data from the API, and also offer the user the option to store them for future use.

Closes #268 