### PR TITLE
Run prediction on N threads

### DIFF
--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -350,7 +350,7 @@ def calc_predicted_points_for_player(
                         is_home,
                         mins,
                         team_model,
-                        df_player,
+                        df_player[position],
                     )
                     + get_defending_points(
                         position, team, opponent, is_home, mins, team_model
@@ -440,10 +440,23 @@ def get_fitted_player_model(
     Get the fitted player model for a given position
     """
     print("Generating player history dataframe - slow")
-    df_player, fits, reals = fit_player_data(
+    df_player, _, _ = fit_player_data(
         player_model, position, season, gameweek, dbsession
     )
     return df_player
+
+
+def get_all_fitted_player_models(
+    player_model, season, gameweek, dbsession=session
+):
+    df_positions = {
+        "GK": None
+    }
+    for pos in ["DEF", "MID", "FWD"]:
+        df_positions[pos], _, _ = fit_player_data(
+            player_model, pos, season, gameweek, dbsession
+        )
+    return df_positions
 
 
 def is_injured_or_suspended(player_api_id, gameweek, season, dbsession=session):

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -280,7 +280,7 @@ def calc_predicted_points_for_player(
     Use the team-level model to get the probs of scoring or conceding
     N goals, and player-level model to get the chance of player scoring
     or assisting given that their team scores.
-    """   
+    """
     if isinstance(player, int):
         player = get_player(player, dbsession=dbsession)
 
@@ -449,12 +449,8 @@ def get_fitted_player_model(
     return df_player
 
 
-def get_all_fitted_player_models(
-    player_model, season, gameweek, dbsession=session
-):
-    df_positions = {
-        "GK": None
-    }
+def get_all_fitted_player_models(player_model, season, gameweek, dbsession=session):
+    df_positions = {"GK": None}
     for pos in ["DEF", "MID", "FWD"]:
         df_positions[pos], _, _ = fit_player_data(
             player_model, pos, season, gameweek, dbsession

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -19,6 +19,7 @@ from airsenal.framework.utils import (
     get_recent_minutes_for_player,
     get_return_gameweek_for_player,
     get_max_matches_per_player,
+    get_player,
     get_player_from_api_id,
     list_players,
     fetcher,
@@ -279,7 +280,9 @@ def calc_predicted_points_for_player(
     Use the team-level model to get the probs of scoring or conceding
     N goals, and player-level model to get the chance of player scoring
     or assisting given that their team scores.
-    """
+    """   
+    if isinstance(player, int):
+        player = get_player(player, dbsession=dbsession)
 
     message = "Points prediction for player {}".format(player.name)
 

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -136,7 +136,7 @@ def calc_all_predicted_points(
             procs.append(processor)
 
         for p in players:
-            queue.put(p)
+            queue.put(p.player_id)
         for _ in range(num_thread):
             queue.put("DONE")
 

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -156,9 +156,8 @@ def calc_all_predicted_points(
                 tag=tag,
                 dbsession=dbsession,
             )
-
-        for p in predictions:
-            dbsession.add(p)
+            for p in predictions:
+                dbsession.add(p)
         dbsession.commit()
         print("Finished adding predictions to db")
 

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -111,7 +111,7 @@ def calc_all_predicted_points(
 
     players = list_players(season=season, gameweek=gw_range[0], dbsession=dbsession)
 
-    if num_thread > 1:
+    if num_thread is not None and num_thread > 1:
         queue = Queue()
         procs = []
         for _ in range(num_thread):

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -19,10 +19,13 @@ from airsenal.framework.utils import (
     NEXT_GAMEWEEK,
     CURRENT_SEASON,
     get_top_predicted_points,
+    list_players,
+    get_player,
 )
 
 from airsenal.framework.prediction_utils import (
-    calc_predicted_points_for_pos,
+    calc_predicted_points_for_player,
+    get_all_fitted_player_models,
     fit_bonus_points,
     fit_save_points,
     fit_card_points,
@@ -35,7 +38,7 @@ def allocate_predictions(
     queue,
     gw_range,
     team_model,
-    player_model,
+    df_player,
     df_bonus,
     df_saves,
     df_cards,
@@ -47,27 +50,26 @@ def allocate_predictions(
     Take positions off the queue and call function to calculate predictions
     """
     while True:
-        pos = queue.get()
-        if pos == "DONE":
-            print("Finished processing {}".format(pos))
+        player = queue.get()
+        if player == "DONE":
+            print("Finished processing")
             break
-        predictions = calc_predicted_points_for_pos(
-            pos=pos,
-            team_model=team_model,
-            player_model=player_model,
-            df_bonus=df_bonus,
-            df_saves=df_saves,
-            df_cards=df_cards,
-            season=season,
+
+        predictions = calc_predicted_points_for_player(
+            player,
+            team_model,
+            df_player,
+            df_bonus,
+            df_saves,
+            df_cards,
+            season,
             gw_range=gw_range,
             tag=tag,
             dbsession=dbsession,
         )
-        for k, v in predictions.items():
-            for playerprediction in v:
-                dbsession.add(playerprediction)
+        for p in predictions:
+            dbsession.add(p)
         dbsession.commit()
-        print("Finished adding predictions to db for {}".format(pos))
 
 
 def calc_all_predicted_points(
@@ -93,7 +95,7 @@ def calc_all_predicted_points(
     with open(model_file, "rb") as f:
         model_player = pickle.load(f)
 
-    #    model_player = get_player_model()
+    df_player = get_all_fitted_player_models(model_player, season, gw_range[0])
 
     if include_bonus:
         df_bonus = fit_bonus_points(gameweek=gw_range[0], season=season)
@@ -108,17 +110,19 @@ def calc_all_predicted_points(
     else:
         df_cards = None
 
-    if num_thread:
+    players = list_players(season=season, gameweek=gw_range[0], dbsession=dbsession)
+
+    if num_thread > 1:
         queue = Queue()
         procs = []
-        for i in range(num_thread):
+        for _ in range(num_thread):
             processor = Process(
                 target=allocate_predictions,
                 args=(
                     queue,
                     gw_range,
                     model_team,
-                    model_player,
+                    df_player,
                     df_bonus,
                     df_saves,
                     df_cards,
@@ -131,33 +135,33 @@ def calc_all_predicted_points(
             processor.start()
             procs.append(processor)
 
-        for pos in ["GK", "DEF", "MID", "FWD"]:
-            queue.put(pos)
-        for i in range(num_thread):
+        for p in players:
+            queue.put(p)
+        for _ in range(num_thread):
             queue.put("DONE")
 
-        for i, p in enumerate(procs):
+        for _, p in enumerate(procs):
             p.join()
     else:
         # single threaded
-        for pos in ["GK", "DEF", "MID", "FWD"]:
-            predictions = calc_predicted_points_for_pos(
-                pos=pos,
-                team_model=model_team,
-                player_model=model_player,
-                df_bonus=df_bonus,
-                df_saves=df_saves,
-                df_cards=df_cards,
-                season=season,
+        for player in players:
+            predictions = calc_predicted_points_for_player(
+                player,
+                model_team,
+                df_player,
+                df_bonus,
+                df_saves,
+                df_cards,
+                season,
                 gw_range=gw_range,
                 tag=tag,
                 dbsession=dbsession,
             )
-            for k, v in predictions.items():
-                for playerprediction in v:
-                    dbsession.add(playerprediction)
+            
+        for p in predictions:
+            dbsession.add(p)
         dbsession.commit()
-        print("Finished adding predictions to db for {}".format(pos))
+        print("Finished adding predictions to db")
 
 
 def make_predictedscore_table(
@@ -239,6 +243,8 @@ def main():
     include_saves = not args.no_saves
 
     with session_scope() as session:
+        session.expire_on_commit = False
+
         tag = make_predictedscore_table(
             gw_range=gw_range,
             season=args.season,

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -20,7 +20,6 @@ from airsenal.framework.utils import (
     CURRENT_SEASON,
     get_top_predicted_points,
     list_players,
-    get_player,
 )
 
 from airsenal.framework.prediction_utils import (
@@ -157,7 +156,7 @@ def calc_all_predicted_points(
                 tag=tag,
                 dbsession=dbsession,
             )
-            
+
         for p in predictions:
             dbsession.add(p)
         dbsession.commit()


### PR DESCRIPTION
Make it possible to run the prediction on N threads instead of one per position (maximum of 4, of which the goalkeeper and forward threads finish much earlier than the defender and midfielder threads).

Currently:
- Fit all the models single-threaded first
- Then add all players to the multiprocessing queue individually.

On my laptop reduces the prediction time from about 5 mins 15 secs to 2 mins 45 secs. Might be able to knock off another ~20 seconds if the model fitting can be done in parallel too. Not a big deal individually but will add up if we start trying to replay whole seasons.