### PR TITLE
Fix/317 discount factor

### DIFF
--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -150,7 +150,7 @@ def get_discount_factor(next_gw, pred_gw, discount_type="exp", discount=14 / 15)
     if not next_gw:
         # during tests 'none' is passed as the root gw, default to zero so the
         # optimisation is done solely on pred_gw ahead.
-        next_gw = 0
+        next_gw = pred_gw
     n_ahead = pred_gw - next_gw
 
     if discount_type in ["exp"]:

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -179,6 +179,7 @@ def make_optimum_single_transfer(
     squad,
     tag,
     gameweek_range=None,
+    root_gw=None,
     season=CURRENT_SEASON,
     update_func_and_args=None,
     bench_boost_gw=None,
@@ -195,6 +196,7 @@ def make_optimum_single_transfer(
     """
     if not gameweek_range:
         gameweek_range = [NEXT_GAMEWEEK]
+        root_gw = NEXT_GAMEWEEK
 
     transfer_gw = min(gameweek_range)  # the week we're making the transfer
     best_score = -1.0
@@ -235,15 +237,15 @@ def make_optimum_single_transfer(
             if gw == bench_boost_gw:
                 total_points += new_squad.get_expected_points(
                     gw, tag, bench_boost=True
-                ) * get_discount_factor(gameweek_range[0], gw)
+                ) * get_discount_factor(root_gw, gw)
             elif gw == triple_captain_gw:
                 total_points += new_squad.get_expected_points(
                     gw, tag, triple_captain=True
-                ) * get_discount_factor(gameweek_range[0], gw)
+                ) * get_discount_factor(root_gw, gw)
             else:
                 total_points += new_squad.get_expected_points(
                     gw, tag
-                ) * get_discount_factor(gameweek_range[0], gw)
+                ) * get_discount_factor(root_gw, gw)
         if total_points > best_score:
             best_score = total_points
             best_pid_out = p_out.player_id
@@ -256,6 +258,7 @@ def make_optimum_double_transfer(
     squad,
     tag,
     gameweek_range=None,
+    root_gw=None,
     season=CURRENT_SEASON,
     update_func_and_args=None,
     bench_boost_gw=None,
@@ -270,6 +273,7 @@ def make_optimum_double_transfer(
     """
     if not gameweek_range:
         gameweek_range = [NEXT_GAMEWEEK]
+        root_gw = NEXT_GAMEWEEK
 
     transfer_gw = min(gameweek_range)  # the week we're making the transfer
     best_score = 0.0
@@ -337,15 +341,15 @@ def make_optimum_double_transfer(
                             if gw == bench_boost_gw:
                                 total_points += new_squad_add_2.get_expected_points(
                                     gw, tag, bench_boost=True
-                                ) * get_discount_factor(gameweek_range[0], gw)
+                                ) * get_discount_factor(root_gw, gw)
                             elif gw == triple_captain_gw:
                                 total_points += new_squad_add_2.get_expected_points(
                                     gw, tag, triple_captain=True
-                                ) * get_discount_factor(gameweek_range[0], gw)
+                                ) * get_discount_factor(root_gw, gw)
                             else:
                                 total_points += new_squad_add_2.get_expected_points(
                                     gw, tag
-                                ) * get_discount_factor(gameweek_range[0], gw)
+                                ) * get_discount_factor(root_gw, gw)
                         if total_points > best_score:
                             best_score = total_points
                             best_pid_out = [pout_1.player_id, pout_2.player_id]
@@ -361,6 +365,7 @@ def make_random_transfers(
     tag,
     nsubs=1,
     gw_range=None,
+    root_gw=None,
     num_iter=1,
     update_func_and_args=None,
     season=CURRENT_SEASON,
@@ -388,6 +393,7 @@ def make_random_transfers(
 
         if not gw_range:
             gw_range = [NEXT_GAMEWEEK]
+            root_gw = NEXT_GAMEWEEK
 
         transfer_gw = min(gw_range)  # the week we're making the transfer
         players_to_remove = []  # this is the index within the squad
@@ -452,15 +458,15 @@ def make_random_transfers(
             if gw == bench_boost_gw:
                 total_points += new_squad.get_expected_points(
                     gw, tag, bench_boost=True
-                ) * get_discount_factor(gw_range[0], gw)
+                ) * get_discount_factor(root_gw, gw)
             elif gw == triple_captain_gw:
                 total_points += new_squad.get_expected_points(
                     gw, tag, triple_captain=True
-                ) * get_discount_factor(gw_range[0], gw)
+                ) * get_discount_factor(root_gw, gw)
             else:
                 total_points += new_squad.get_expected_points(
                     gw, tag
-                ) * get_discount_factor(gw_range[0], gw)
+                ) * get_discount_factor(root_gw, gw)
         if total_points > best_score:
             best_score = total_points
             best_pid_out = removed_players
@@ -475,9 +481,11 @@ def make_best_transfers(
     squad,
     tag,
     gameweeks,
+    root_gw,
     season,
     num_iter=100,
     update_func_and_args=None,
+
 ):
     """
     Return a new squad and a dictionary {"in": [player_ids],
@@ -509,6 +517,7 @@ def make_best_transfers(
             squad,
             tag,
             gameweeks,
+            root_gw,
             season,
             triple_captain_gw=triple_captain_gw,
             bench_boost_gw=bench_boost_gw,
@@ -522,6 +531,7 @@ def make_best_transfers(
             squad,
             tag,
             gameweeks,
+            root_gw,
             season,
             triple_captain_gw=triple_captain_gw,
             bench_boost_gw=bench_boost_gw,

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -147,6 +147,7 @@ def get_discount_factor(next_gw, pred_gw, discount_type="exp", discount=14 / 15)
     if discount_type not in allowed_types:
         raise Exception("unrecognised discount type, should be exp or const")
 
+    if not next_gw: next_gw = 0 #during tests 'none' is passed as the root gw, default to zero so the optimisation is done solely on pred_gw ahead.
     n_ahead = pred_gw - next_gw
 
     if discount_type in ["exp"]:

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -562,7 +562,7 @@ def make_best_transfers(
         tag,
         triple_captain=(triple_captain_gw is not None),
         bench_boost=(bench_boost_gw is not None),
-    )
+    ) *get_discount_factor(root_gw, gameweeks[0])
 
     if num_transfers == "F":
         # Free Hit changes don't apply to next gameweek, so return the original squad

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -147,7 +147,10 @@ def get_discount_factor(next_gw, pred_gw, discount_type="exp", discount=14 / 15)
     if discount_type not in allowed_types:
         raise Exception("unrecognised discount type, should be exp or const")
 
-    if not next_gw: next_gw = 0 #during tests 'none' is passed as the root gw, default to zero so the optimisation is done solely on pred_gw ahead.
+    if not next_gw:
+        # during tests 'none' is passed as the root gw, default to zero so the
+        # optimisation is done solely on pred_gw ahead.
+        next_gw = 0
     n_ahead = pred_gw - next_gw
 
     if discount_type in ["exp"]:
@@ -486,7 +489,6 @@ def make_best_transfers(
     season,
     num_iter=100,
     update_func_and_args=None,
-
 ):
     """
     Return a new squad and a dictionary {"in": [player_ids],
@@ -558,12 +560,15 @@ def make_best_transfers(
         )
 
     # get the expected points total for next gameweek
-    points = new_squad.get_expected_points(
-        gameweeks[0],
-        tag,
-        triple_captain=(triple_captain_gw is not None),
-        bench_boost=(bench_boost_gw is not None),
-    ) *get_discount_factor(root_gw, gameweeks[0])
+    points = (
+        new_squad.get_expected_points(
+            gameweeks[0],
+            tag,
+            triple_captain=(triple_captain_gw is not None),
+            bench_boost=(bench_boost_gw is not None),
+        )
+        * get_discount_factor(root_gw, gameweeks[0])
+    )
 
     if num_transfers == "F":
         # Free Hit changes don't apply to next gameweek, so return the original squad

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -40,6 +40,7 @@ from airsenal.framework.optimization_utils import (
     count_expected_outputs,
     next_week_transfers,
     check_tag_valid,
+    get_discount_factor
 )
 
 from airsenal.framework.utils import (

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -147,7 +147,7 @@ def optimize(
             strat_dict["chips_played"] = {}
             new_squad = squad
             gw = gameweek_range[0] - 1
-            strat_dict["root_gw"] = gw
+            strat_dict["root_gw"] = gameweek_range[0]
         else:
             if len(sid) > 0:
                 sid += "-"

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -268,10 +268,11 @@ def save_baseline_score(squad, gameweeks, tag, season=CURRENT_SEASON):
     """When strategies with unused transfers are excluded the baseline strategy will
     normally not be part of the tree. In that case save it first with this function.
     """
-    # TODO: Discount factor, use season argument
+    # TODO: use season argument
+    root_gw = gameweeks[0]
     score = 0
     for gw in gameweeks:
-        score += squad.get_expected_points(gw, tag)
+        score += squad.get_expected_points(gw, tag) * get_discount_factor(root_gw, gw)
     num_gameweeks = len(gameweeks)
     zeros = ("0-" * num_gameweeks)[:-1]
     filename = os.path.join(OUTPUT_DIR, "strategy_{}_{}.json".format(tag, zeros))

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -270,14 +270,27 @@ def save_baseline_score(squad, gameweeks, tag, season=CURRENT_SEASON):
     """
     # TODO: use season argument
     root_gw = gameweeks[0]
-    score = 0
+    strat_dict = {
+        "total_score": 0,
+        "points_per_gw": {},
+        "players_in": {},
+        "players_out": {},
+        "chips_played": {},
+        "root_gw": root_gw
+    }
     for gw in gameweeks:
-        score += squad.get_expected_points(gw, tag) * get_discount_factor(root_gw, gw)
+        gw_score = squad.get_expected_points(gw, tag) * get_discount_factor(root_gw, gw)
+        strat_dict["total_sore"] += gw_score
+        strat_dict["points_per_gw"][gw] = gw_score
+        strat_dict["players_in"][gw] = []
+        strat_dict["players_out"][gw] = []
+        strat_dict["chips_played"][gw] = None
+
     num_gameweeks = len(gameweeks)
     zeros = ("0-" * num_gameweeks)[:-1]
     filename = os.path.join(OUTPUT_DIR, "strategy_{}_{}.json".format(tag, zeros))
     with open(filename, "w") as f:
-        json.dump({"total_score": score}, f)
+        json.dump(strat_dict, f)
 
 
 def find_baseline_score_from_json(tag, num_gameweeks):

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -193,7 +193,7 @@ def optimize(
                 (updater, increment, pid),
             )
 
-            points -= (calc_points_hit(num_transfers, free_transfers) * get_discount_factor(root_gw, gw)
+            points -= (calc_points_hit(num_transfers, free_transfers) * get_discount_factor(root_gw, gw))
             strat_dict["total_score"] += points
             strat_dict["points_per_gw"][gw] = points
 

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -146,6 +146,7 @@ def optimize(
             strat_dict["chips_played"] = {}
             new_squad = squad
             gw = gameweek_range[0] - 1
+            strat_dict["root_gw"] = gw
         else:
             if len(sid) > 0:
                 sid += "-"
@@ -185,6 +186,7 @@ def optimize(
                 squad,
                 pred_tag,
                 gameweeks,
+                strat_dict["root_gw"],
                 season,
                 num_iterations,
                 (updater, increment, pid),
@@ -612,14 +614,20 @@ def main():
 
     sanity_check_args(args)
     season = args.season
+    #default weeks ahead is not specified (or gw_end is not specified) is three
     if args.weeks_ahead:
         gameweeks = list(
             range(get_next_gameweek(), get_next_gameweek() + args.weeks_ahead)
         )
+    elif args.gw_start:
+        if args.gw_end:
+            gameweeks = list(range(args.gw_start, args.gw_end))
+        else:
+            gameweeks = list(range(args.gw_start, args.gw_start + 3))
     else:
-        gameweeks = list(range(args.gw_start, args.gw_end))
-    num_iterations = args.num_iterations
+        gameweeks = list(range(get_next_gameweek(), get_next_gameweek() + 3))
 
+    num_iterations = args.num_iterations
     if args.num_free_transfers:
         num_free_transfers = args.num_free_transfers
     else:

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -282,7 +282,7 @@ def save_baseline_score(squad, gameweeks, tag, season=CURRENT_SEASON):
     }
     for gw in gameweeks:
         gw_score = squad.get_expected_points(gw, tag) * get_discount_factor(root_gw, gw)
-        strat_dict["total_sore"] += gw_score
+        strat_dict["total_score"] += gw_score
         strat_dict["points_per_gw"][gw] = gw_score
         strat_dict["players_in"][gw] = []
         strat_dict["players_out"][gw] = []

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -161,6 +161,7 @@ def optimize(
 
             # upcoming gameweek:
             gw = gameweeks[0]
+            root_gw = strat_dict["root_gw"]
 
             # check whether we're playing a chip this gameweek
             if isinstance(num_transfers, str):
@@ -186,13 +187,13 @@ def optimize(
                 squad,
                 pred_tag,
                 gameweeks,
-                strat_dict["root_gw"],
+                root_gw,
                 season,
                 num_iterations,
                 (updater, increment, pid),
             )
 
-            points -= calc_points_hit(num_transfers, free_transfers)
+            points -= (calc_points_hit(num_transfers, free_transfers) * get_discount_factor(root_gw, gw)
             strat_dict["total_score"] += points
             strat_dict["points_per_gw"][gw] = points
 

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -40,7 +40,7 @@ from airsenal.framework.optimization_utils import (
     count_expected_outputs,
     next_week_transfers,
     check_tag_valid,
-    get_discount_factor
+    get_discount_factor,
 )
 
 from airsenal.framework.utils import (
@@ -194,7 +194,9 @@ def optimize(
                 (updater, increment, pid),
             )
 
-            points -= (calc_points_hit(num_transfers, free_transfers) * get_discount_factor(root_gw, gw))
+            points -= calc_points_hit(
+                num_transfers, free_transfers
+            ) * get_discount_factor(root_gw, gw)
             strat_dict["total_score"] += points
             strat_dict["points_per_gw"][gw] = points
 
@@ -276,7 +278,7 @@ def save_baseline_score(squad, gameweeks, tag, season=CURRENT_SEASON):
         "players_in": {},
         "players_out": {},
         "chips_played": {},
-        "root_gw": root_gw
+        "root_gw": root_gw,
     }
     for gw in gameweeks:
         gw_score = squad.get_expected_points(gw, tag) * get_discount_factor(root_gw, gw)
@@ -630,7 +632,7 @@ def main():
 
     sanity_check_args(args)
     season = args.season
-    #default weeks ahead is not specified (or gw_end is not specified) is three
+    # default weeks ahead is not specified (or gw_end is not specified) is three
     if args.weeks_ahead:
         gameweeks = list(
             range(get_next_gameweek(), get_next_gameweek() + args.weeks_ahead)


### PR DESCRIPTION
Issue #317. 

- Root gameweek is passed to the optimise transfer functions so that the discount factor is correctly applied to the root gameweek of the tree optimisation, rather than the gameweek corresponding to the current tree depth.
- Discount factor now applied to the points returned by `make_best_transfers`, and also to the points deducted by excess transfers. 

