### PR TITLE
Add injury status and return gameweek to the database

### DIFF
--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -335,7 +335,7 @@ def calc_predicted_points_for_player(
             # calculate appearance points, defending points, attacking points.
             points = 0.0
 
-        elif is_injured_or_suspended(player.fpl_api_id, gameweek, season, dbsession):
+        elif player.is_injured_or_suspended(season, gw_range[0], gameweek):
             # Points for fixture will be zero if suspended or injured
             points = 0.0
 
@@ -456,27 +456,6 @@ def get_all_fitted_player_models(player_model, season, gameweek, dbsession=sessi
             player_model, pos, season, gameweek, dbsession
         )
     return df_positions
-
-
-def is_injured_or_suspended(player_api_id, gameweek, season, dbsession=session):
-    """
-    Query the API for 'chance of playing next round', and if this
-    is <=50%, see if we can find a return date.
-    """
-    if season != CURRENT_SEASON:  # no API info for past seasons
-        return False
-    # check if a player is injured or suspended
-    pdata = fetcher.get_player_summary_data()[player_api_id]
-    if (
-        "chance_of_playing_next_round" in pdata.keys()
-        and pdata["chance_of_playing_next_round"] is not None
-        and pdata["chance_of_playing_next_round"] <= 50
-    ):
-        # check if we have a return date
-        return_gameweek = get_return_gameweek_for_player(player_api_id, dbsession)
-        if return_gameweek is None or return_gameweek > gameweek:
-            return True
-    return False
 
 
 def fill_ep(csv_filename, dbsession=session):

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -17,7 +17,6 @@ from airsenal.framework.utils import (
     NEXT_GAMEWEEK,
     get_fixtures_for_player,
     get_recent_minutes_for_player,
-    get_return_gameweek_for_player,
     get_max_matches_per_player,
     get_player,
     get_player_from_api_id,

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -9,8 +9,6 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 from contextlib import contextmanager
 
-from sqlalchemy.sql.operators import notendswith_op
-
 from airsenal.framework.db_config import DB_CONNECTION_STRING
 
 Base = declarative_base()

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -34,39 +34,12 @@ class Player(Base):
         at least one gameweek in specified season, return a best guess value
         based on data nearest to specified gameweek.
         """
-        gw_before = 0
-        gw_after = 100
-        team_before = None
-        team_after = None
-
-        for attr in self.attributes:
-            if attr.season != season:
-                continue
-
-            if attr.gameweek == gameweek:
-                return attr.team
-            elif (attr.gameweek < gameweek) and (attr.gameweek > gw_before):
-                # update last available team before specified gameweek
-                gw_before = attr.gameweek
-                team_before = attr.team
-            elif (attr.gameweek > gameweek) and (attr.gameweek < gw_after):
-                # update next available team after specified gameweek
-                gw_after = attr.gameweek
-                team_after = attr.team
-
-        # ran through all attributes without finding gameweek, return an
-        # appropriate estimate
-        if not team_before and not team_after:
+        attr = self.get_gameweek_attributes(season, gameweek)
+        if attr is not None:
+            return attr.team
+        else:
             print("No team found for", self.name, "in", season, "season.")
             return None
-        elif not team_after:
-            return team_before
-        elif not team_before:
-            return team_after
-        elif (gw_after - gameweek) >= (gameweek - gw_before):
-            return team_before
-        else:
-            return team_after
 
     def price(self, season, gameweek):
         """
@@ -75,51 +48,36 @@ class Player(Base):
         at least one gameweek in specified season, return a best guess value
         based on data nearest to specified gameweek.
         """
-        gw_before = 0
-        gw_after = 100
-        price_before = None
-        price_after = None
+        attr = self.get_gameweek_attributes(season, gameweek, before_and_after=True)
+        if attr is not None:
+            if isinstance(attr, tuple):
+                # interpolate price between nearest available gameweeks
+                gw_before = attr[0].gameweek
+                price_before = attr[0].price
+                gw_after = attr[1].gameweek
+                price_after = attr[1].price
 
-        for attr in self.attributes:
-            if attr.season != season:
-                continue
+                gradient = (price_after - price_before) / (gw_after - gw_before)
+                intercept = price_before - gradient * gw_before
+                price = gradient * gameweek + intercept
+                return round(price)
 
-            if attr.gameweek == gameweek:
+            else:
                 return attr.price
-            elif (attr.gameweek < gameweek) and (attr.gameweek > gw_before):
-                # update last available price before specified gameweek
-                gw_before = attr.gameweek
-                price_before = attr.price
-            elif (attr.gameweek > gameweek) and (attr.gameweek < gw_after):
-                # update next available price after specified gameweek
-                gw_after = attr.gameweek
-                price_after = attr.price
-
-        # ran through all attributes without finding gameweek, return an
-        # appropriate estimate
-        if not price_before and not price_after:
+        else:
             print("No price found for", self.name, "in", season, "season.")
             return None
-        elif not price_after:
-            return price_before
-        elif not price_before:
-            return price_after
-        else:
-            # found a price before and after the requested gameweek,
-            # interpolate between the two
-            gradient = (price_after - price_before) / (gw_after - gw_before)
-            intercept = price_before - gradient * gw_before
-            price = gradient * gameweek + intercept
-            return round(price)
 
     def position(self, season):
         """
         get player's position for given season
         """
-        for attr in self.attributes:
-            if attr.season == season:
-                return attr.position
-        return None
+        attr = self.get_gameweek_attributes(season, None)
+        if attr is not None:
+            return attr.position
+        else:
+            print("No position found for", self.name, "in", season, "season.")
+            return None
 
     def is_injured_or_suspended(self, season, current_gw, fixture_gw):
         """Check whether a player is injured or suspended (<=50% chance of playing).
@@ -129,18 +87,65 @@ class Player(Base):
         is available for, i.e. we are checking whether the player is availiable in the
         future week "fixture_gw" at the previous point in time "current_gw".
         """
+        attr = self.get_gameweek_attributes(season, current_gw)
+        if attr is not None:
+            if (
+                attr.chance_of_playing_next_round is not None
+                and attr.chance_of_playing_next_round <= 50
+            ) and (attr.return_gameweek is None or attr.return_gameweek > fixture_gw):
+                return True
+            else:
+                return False
+        else:
+            return False
+
+    def get_gameweek_attributes(self, season, gameweek, before_and_after=False):
+        """Get the PlayerAttributes object for this player in the given gameweek and
+        season, or the nearest available gameweek(s) if the exact gameweek is not
+        available.
+        If no attributes available in the specified season, return None in all cases.
+        If before_and_after is True and an exact gameweek & season match is not found,
+        return both the nearest gameweek before and after the specified gameweek.
+        """
+        gw_before = 0
+        gw_after = 100
+        attr_before = None
+        attr_after = None
+
         for attr in self.attributes:
-            if attr.season == season and attr.gameweek == current_gw:
-                if (
-                    attr.chance_of_playing_next_round is not None
-                    and attr.chance_of_playing_next_round <= 50
-                ) and (
-                    attr.return_gameweek is None or attr.return_gameweek > fixture_gw
-                ):
-                    return True
-                else:
-                    return False
-        return False
+            if attr.season != season:
+                continue
+
+            if gameweek is None:
+                # trying to match season only
+                return attr
+            elif attr.gameweek == gameweek:
+                return attr
+            elif (attr.gameweek < gameweek) and (attr.gameweek > gw_before):
+                # update last available attr before specified gameweek
+                gw_before = attr.gameweek
+                attr_before = attr
+            elif (attr.gameweek > gameweek) and (attr.gameweek < gw_after):
+                # update next available attr after specified gameweek
+                gw_after = attr.gameweek
+                attr_after = attr
+
+        # ran through all attributes without finding exact gameweek and season match
+        if attr_before is None and attr_after is None:
+            # no attributes for this player in this season
+            return None
+        elif not attr_after:
+            return attr_before
+        elif not attr_before:
+            return attr_after
+        elif before_and_after:
+            return (attr_before, attr_after)
+        else:
+            # return attributes at gameweeek nearest to input gameweek
+            if (gw_after - gameweek) >= (gameweek - gw_before):
+                return attr_before
+            else:
+                return attr_after
 
 
 class PlayerAttributes(Base):

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -955,23 +955,20 @@ def get_top_predicted_points(
             print("-" * 25)
 
 
-def get_return_gameweek_for_player(player_api_id, dbsession=None):
+def get_return_gameweek_from_news(news, dbsession=None):
+    """Parse news strings from the FPL API for the return date of injured or
+    suspended players. If a date is found, determine and return the gameweek it
+    corresponds to.
     """
-    If  a player is injured and there is 'news' about them on FPL,
-    parse this string to get expected return date.
-    """
-    pdata = fetcher.get_player_summary_data()[player_api_id]
     rd_rex = "(Expected back|Suspended until)[\\s]+([\\d]+[\\s][\\w]{3})"
-    if "news" in pdata.keys() and re.search(rd_rex, pdata["news"]):
-
-        return_str = re.search(rd_rex, pdata["news"]).groups()[1]
+    if re.search(rd_rex, news):
+        return_str = re.search(rd_rex, news).groups()[1]
         # return_str should be a day and month string (without year)
 
         # create a date in the future from the day and month string
         return_date = dateparser.parse(
             return_str, settings={"PREFER_DATES_FROM": "future"}
         )
-
         if not return_date:
             raise ValueError(
                 "Failed to parse date from string '{}'".format(return_date)
@@ -979,6 +976,7 @@ def get_return_gameweek_for_player(player_api_id, dbsession=None):
 
         return_gameweek = get_gameweek_by_date(return_date, dbsession=dbsession)
         return return_gameweek
+
     return None
 
 

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -231,7 +231,9 @@ def get_squad_value(
     return total_value
 
 
-def get_sell_price_for_player(player_id, gameweek=None, fpl_team_id=None):
+def get_sell_price_for_player(
+    player_id, gameweek=None, fpl_team_id=None, dbsession=session
+):
     """
     find the price we bought the player for,
     and the price at the specified gameweek,
@@ -240,7 +242,7 @@ def get_sell_price_for_player(player_id, gameweek=None, fpl_team_id=None):
     """
     if not fpl_team_id:
         fpl_team_id = fetcher.FPL_TEAM_ID
-    transactions = session.query(Transaction)
+    transactions = dbsession.query(Transaction)
     transactions = transactions.filter_by(fpl_team_id=fpl_team_id)
     transactions = transactions.filter_by(player_id=player_id)
     transactions = transactions.order_by(Transaction.gameweek).all()
@@ -433,7 +435,7 @@ def get_player_id(player_name, dbsession=None):
     # not found by name in DB - try alternative names
     for k, v in alternative_player_names.items():
         if player_name in v:
-            p = session.query(Player).filter_by(name=k).first()
+            p = dbsession.query(Player).filter_by(name=k).first()
             if p:
                 return p.player_id
             break
@@ -715,13 +717,13 @@ def get_fixtures_for_gameweek(gameweek, season=CURRENT_SEASON, dbsession=session
 
 def get_result_for_fixture(fixture, dbsession=session):
     """Get result for a fixture."""
-    result = session.query(Result).filter_by(fixture=fixture).all()
+    result = dbsession.query(Result).filter_by(fixture=fixture).all()
     return result
 
 
 def get_player_scores_for_fixture(fixture, dbsession=session):
     """Get player scores for a fixture."""
-    player_scores = session.query(PlayerScore).filter_by(fixture=fixture).all()
+    player_scores = dbsession.query(PlayerScore).filter_by(fixture=fixture).all()
     return player_scores
 
 
@@ -744,20 +746,20 @@ def get_players_for_gameweek(gameweek, fpl_team_id=None):
     return player_list
 
 
-def get_previous_points_for_same_fixture(player, fixture_id):
+def get_previous_points_for_same_fixture(player, fixture_id, dbsession=session):
     """
     Search the past matches for same fixture in past seasons,
     and how many points the player got.
     """
     if isinstance(player, str):
-        player_record = session.query(Player).filter_by(name=player).first()
+        player_record = dbsession.query(Player).filter_by(name=player).first()
         if not player_record:
             print("Can't find player {}".format(player))
             return {}
         player_id = player_record.player_id
     else:
         player_id = player
-    fixture = session.query(Fixture).filter_by(fixture_id=fixture_id).first()
+    fixture = dbsession.query(Fixture).filter_by(fixture_id=fixture_id).first()
     if not fixture:
         print("Couldn't find fixture_id {}".format(fixture_id))
         return {}
@@ -765,7 +767,7 @@ def get_previous_points_for_same_fixture(player, fixture_id):
     away_team = fixture.away_team
 
     previous_matches = (
-        session.query(Fixture)
+        dbsession.query(Fixture)
         .filter_by(home_team=home_team)
         .filter_by(away_team=away_team)
         .order_by(Fixture.season)
@@ -775,7 +777,7 @@ def get_previous_points_for_same_fixture(player, fixture_id):
     previous_points = {}
     for fid in fixture_ids:
         scores = (
-            session.query(PlayerScore)
+            dbsession.query(PlayerScore)
             .filter_by(player_id=player_id, fixture_id=fid[0])
             .all()
         )

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -19,6 +19,7 @@ from airsenal.framework.utils import (
     CURRENT_SEASON,
     get_player_attributes,
     get_player_team_from_fixture,
+    get_return_gameweek_from_news,
 )
 
 from airsenal.framework.data_fetcher import FPLDataFetcher
@@ -115,6 +116,16 @@ def fill_attributes_table_from_api(
         pa.transfers_in = int(p_summary["transfers_in_event"])
         pa.transfers_out = int(p_summary["transfers_out_event"])
         pa.transfers_balance = pa.transfers_in - pa.transfers_out
+        pa.chance_of_playing_next_round = p_summary["chance_of_playing_next_round"]
+        pa.news = p_summary["news"]
+        if (
+            pa.chance_of_playing_next_round is not None
+            and pa.chance_of_playing_next_round <= 50
+        ):
+            pa.return_gameweek = get_return_gameweek_from_news(
+                p_summary["news"],
+                dbsession=dbsession,
+            )
 
         if not update:
             # only need to add to the dbsession for new entries, if we're doing


### PR DESCRIPTION
Add the current injury/suspension status and expected return gameweek to the database (attributes table). Move `is_injured_or_suspended` function to the `Player` class. Get the current value for the fields for all players when running `airsenal_setup_initial_db` and `airsenal_update_db`.

For #159