### PR TITLE
Fixes and improvements to database updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *FD_API_KEY
 *FPL_LOGIN
 *FPL_PASSWORD
+*AIrsenalDBFile
+*AIrsenalDBUri
+*AIrsenalDBUser
+*AIrsenalDBPassword
 
 # compiled stan models
 stan_model/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Once you've installed the module, you will need to set the following parameters:
 
 4. `FPL_PASSWORD`: your FPL password (this is only required to get FPL league standings).
 
+5. `AIrsenalDBFile`: Local path to where you would like to store the AIrsenal sqlite3 database. If not set a temporary directory will be used by default (`/tmp/data.db` on Unix systems).
+
 The values for these should be defined either in environment variables with the names given above, or as files in the `airsenal/data` directory with the names given above. For example, to set your team ID you can create the file `airsenal/data/FPL_TEAM_ID` (with no file extension) and its contents should be your team ID and nothing else. So the contents of the file would just be something like:
 ```
 1234567
@@ -88,7 +90,6 @@ If you installed AIrsenal with conda, you should always make sure the `airsenale
 ```shell
 conda activate airsenalenv
 ```
-
 
 Note: Most the commands below can be run with the `--help` flag to see additional options and information.
 
@@ -144,7 +145,7 @@ Instead of running the commands above individually you can use:
 ```shell
 airsenal_run_pipeline
 ```
-This will delete and recreate the database and then run the points predictions and transfer optimization.
+This will update the database and then run the points predictions and transfer optimization.
 
 ## Docker
 

--- a/airsenal/framework/db_config.py
+++ b/airsenal/framework/db_config.py
@@ -1,27 +1,68 @@
 """
 Database can be either an sqlite file or a postgress server
 """
-
 import os
 from airsenal import TMPDIR
 
-# Default connection string points to a local sqlite file in
-# airsenal/data/data.db
-
-DB_CONNECTION_STRING = "sqlite:///{}/data.db".format(TMPDIR)
+config_path = os.path.join(os.path.dirname(__file__), "..", "data")
+AIrsenalDBFile_path = os.path.join(config_path, "AIrsenalDBFile")
+AIrsenalDBUri_path = os.path.join(config_path, "AIrsenalDBUri")
+AIrsenalDBUser_path = os.path.join(config_path, "AIrsenalDBUser")
+AIrsenalDBPassword_path = os.path.join(config_path, "AIrsenalDBPassword")
 
 # Check that we're not trying to set location for both sqlite and postgres
-if "AIrsenalDBFile" in os.environ.keys() and "AIrsenalDBUri" in os.environ.keys():
+if ("AIrsenalDBFile" in os.environ.keys() or os.path.exists(AIrsenalDBFile_path)) and (
+    "AIrsenalDBUri" in os.environ.keys() or os.path.exists(AIrsenalDBUri_path)
+):
     raise RuntimeError("Please choose only ONE of AIrsenalDBFile and AIrsenalDBUri")
 
-# location of sqlite file overridden by an env var
+# sqlite database in a local file with path specified by:
+# - AIrsenalDBFile environment variable
+# - airsenal/data/AIrsenalDBFile file
+# - platform-dependent temporary directory (default)
 if "AIrsenalDBFile" in os.environ.keys():
-    DB_CONNECTION_STRING = "sqlite:///{}".format(os.environ["AIrsenalDBFile"])
+    AIrsenalDBFile = os.environ["AIrsenalDBFile"]
+elif os.path.exists(AIrsenalDBFile_path):
+    AIrsenalDBFile = open(AIrsenalDBFile_path).read().strip()
+else:
+    AIrsenalDBFile = os.path.join(TMPDIR, "data.db")
 
-# location of postgres server
-if "AIrsenalDBUri" in os.environ.keys():
+DB_CONNECTION_STRING = "sqlite:///{}".format(AIrsenalDBFile)
+
+# postgres database specified by: AIrsenalDBUri, AIrsenalDBUser, AIrsenalDBPassword
+# defined either as:
+# - environment variables
+# - Files in airsenal/data/
+if "AIrsenalDBUri" in os.environ.keys() or os.path.exists(AIrsenalDBUri_path):
+    if "AIrsenalDBUser" in os.environ.keys():
+        AIrsenalDBUser = os.environ["AIrsenalDBUser"]
+    elif os.path.exists(AIrsenalDBUser_path):
+        AIrsenalDBUser = open(AIrsenalDBUser_path).read().strip()
+    else:
+        raise RuntimeError(
+            "AIrsenalDBUser must be defined when using a postgres database"
+        )
+
+    if "AIrsenalDBUser" in os.environ.keys():
+        AIrsenalDBPassword = os.environ["AIrsenalDBPassword"]
+    elif os.path.exists(AIrsenalDBPassword_path):
+        AIrsenalDBPassword = open(AIrsenalDBPassword_path).read().strip()
+    else:
+        raise RuntimeError(
+            "AIrsenalDBPassword must be defined when using a postgres database"
+        )
+
+    if "AIrsenalDBUri" in os.environ.keys():
+        AIrsenalDBUri = os.environ["AIrsenalDBUri"]
+    elif os.path.exists(AIrsenalDBUri_path):
+        AIrsenalDBUri = open(AIrsenalDBUri_path).read().strip()
+    else:
+        raise RuntimeError(
+            "AIrsenalDBUri must be defined when using a postgres database"
+        )
+
     DB_CONNECTION_STRING = "postgres://{}:{}@{}/airsenal".format(
-        os.environ["AIrsenalDBUser"],
-        os.environ["AIrsenalDBPassword"],
-        os.environ["AIrsenalDBUri"],
+        AIrsenalDBUser,
+        AIrsenalDBPassword,
+        AIrsenalDBUri,
     )

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -114,7 +114,7 @@ def get_starting_squad(fpl_team_id=None):
     # chip is activated
     transactions = (
         session.query(Transaction)
-        .order_by(Transaction.id)
+        .order_by(Transaction.gameweek, Transaction.id)
         .filter_by(fpl_team_id=fpl_team_id)
         .filter_by(free_hit=0)
         .all()

--- a/airsenal/framework/player.py
+++ b/airsenal/framework/player.py
@@ -38,6 +38,9 @@ class CandidatePlayer(object):
         self.predicted_points = {}
         self.sub_position = None
 
+    def __str__(self):
+        return self.name
+
     def calc_predicted_points(self, method):
         """
         get expected points from the db.

--- a/airsenal/framework/player.py
+++ b/airsenal/framework/player.py
@@ -58,10 +58,6 @@ class CandidatePlayer(object):
         if method not in self.predicted_points.keys():
             self.calc_predicted_points(method)
         if gameweek not in self.predicted_points[method].keys():
-            print(
-                "No prediction available for {} week {}".format(
-                    self.data.name, gameweek
-                )
-            )
+            print("No prediction available for {} week {}".format(self.name, gameweek))
             return 0.0
         return self.predicted_points[method][gameweek]

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -86,11 +86,7 @@ def get_player_history_df(
 
             match_id = row.result_id
             if not match_id:
-                print(
-                    " Couldn't find result for {}".format(
-                        row.fixture
-                    )
-                )
+                print(" Couldn't find result for {}".format(row.fixture))
                 continue
             minutes = row.minutes
             goals = row.goals

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -70,7 +70,7 @@ def get_player_history_df(
     for counter, player in enumerate(players):
         print(
             "Filling history dataframe for {}: {}/{} done".format(
-                player.name, counter, len(players)
+                player, counter, len(players)
             )
         )
         results = player.scores
@@ -283,7 +283,7 @@ def calc_predicted_points_for_player(
     if isinstance(player, int):
         player = get_player(player, dbsession=dbsession)
 
-    message = "Points prediction for player {}".format(player.name)
+    message = "Points prediction for player {}".format(player)
 
     if not gw_range:
         # by default, go for next three matches

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -87,8 +87,8 @@ def get_player_history_df(
             match_id = row.result_id
             if not match_id:
                 print(
-                    " Couldn't find result for {} {} {}".format(
-                        row.fixture.home_team, row.fixture.away_team, row.fixture.date
+                    " Couldn't find result for {}".format(
+                        row.fixture
                     )
                 )
                 continue

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -147,6 +147,9 @@ class Player(Base):
             else:
                 return attr_after
 
+    def __str__(self):
+        return f"{self.name}"
+
 
 class PlayerAttributes(Base):
     __tablename__ = "player_attributes"
@@ -191,6 +194,9 @@ class Fixture(Base):
     result = relationship("Result", uselist=False, back_populates="fixture")
     player = relationship("Player", back_populates="fixtures")
     player_id = Column(Integer, ForeignKey("player.player_id"))
+
+    def __str__(self):
+        return f"{self.season} GW{self.gameweek} {self.home_team} vs. {self.away_team}"
 
 
 class PlayerScore(Base):

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -148,7 +148,7 @@ class Player(Base):
                 return attr_after
 
     def __str__(self):
-        return f"{self.name}"
+        return self.name
 
 
 class PlayerAttributes(Base):

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -286,6 +286,7 @@ class Transaction(Base):
     gameweek = Column(Integer, nullable=False)
     bought_or_sold = Column(Integer, nullable=False)  # +1 for bought, -1 for sold
     season = Column(String(100), nullable=False)
+    time = Column(String(100), nullable=False)
     tag = Column(String(100), nullable=False)
     price = Column(Integer, nullable=False)
     free_hit = Column(Integer, nullable=False)  # 1 if transfer on Free Hit, 0 otherwise

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -170,6 +170,12 @@ class PlayerAttributes(Base):
     transfers_in = Column(Integer, nullable=True)
     transfers_out = Column(Integer, nullable=True)
 
+    def __str__(self):
+        return (
+            f"{self.player} ({self.season} GW{self.gameweek}): "
+            f"£{self.price / 10}, {self.team}, {self.position}"
+        )
+
 
 class Result(Base):
     __tablename__ = "result"
@@ -180,6 +186,13 @@ class Result(Base):
     away_score = Column(Integer, nullable=False)
     player = relationship("Player", back_populates="results")
     player_id = Column(Integer, ForeignKey("player.player_id"))
+
+    def __str__(self):
+        return (
+            f"{self.fixture.season} GW{self.fixture.gameweek} "
+            f"{self.fixture.home_team} {self.home_score} - "
+            f"{self.away_score} {self.fixture.away_team}"
+        )
 
 
 class Fixture(Base):
@@ -196,7 +209,13 @@ class Fixture(Base):
     player_id = Column(Integer, ForeignKey("player.player_id"))
 
     def __str__(self):
-        return f"{self.season} GW{self.gameweek} {self.home_team} vs. {self.away_team}"
+        if self.result:
+            return str(self.result)
+        else:
+            return (
+                f"{self.season} GW{self.gameweek} "
+                f"{self.home_team} vs. {self.away_team}"
+            )
 
 
 class PlayerScore(Base):
@@ -232,6 +251,19 @@ class PlayerScore(Base):
     threat = Column(Float, nullable=True)
     ict_index = Column(Float, nullable=True)
 
+    def __str__(self):
+        score_str = (
+            f"{self.player} ({self.result}): " f"{self.points} pts, {self.minutes} mins"
+        )
+        if self.goals > 0:
+            score_str += f", {self.goals} goals"
+        if self.assists > 0:
+            score_str += f", {self.assists} assists"
+        if self.bonus > 0:
+            score_str += f", {self.bonus} bonus"
+
+        return score_str
+
 
 class PlayerPrediction(Base):
     __tablename__ = "player_prediction"
@@ -242,6 +274,9 @@ class PlayerPrediction(Base):
     tag = Column(String(100), nullable=False)
     player = relationship("Player", back_populates="predictions")
     player_id = Column(Integer, ForeignKey("player.player_id"))
+
+    def __str__(self):
+        return f"{self.player}: Predict {self.predicted_points} pts in {self.fixture}"
 
 
 class Transaction(Base):
@@ -256,6 +291,16 @@ class Transaction(Base):
     free_hit = Column(Integer, nullable=False)  # 1 if transfer on Free Hit, 0 otherwise
     fpl_team_id = Column(Integer, nullable=False)
 
+    def __str__(self):
+        trans_str = f"{self.season} GW{self.gameweek}: "
+        if self.bought_or_sold == 1:
+            trans_str += f"Team {self.fpl_team_id} bought player {self.player_id}"
+        else:
+            trans_str += f"Team {self.fpl_team_id} bought player {self.player_id}"
+        if self.free_hit:
+            trans_str += " (FREE HIT)"
+        return trans_str
+
 
 class TransferSuggestion(Base):
     __tablename__ = "transfer_suggestion"
@@ -266,6 +311,18 @@ class TransferSuggestion(Base):
     points_gain = Column(Float, nullable=False)
     timestamp = Column(String(100), nullable=False)  # use this to group suggestions
     season = Column(String(100), nullable=False)
+
+    def __str__(self):
+        sugg_str = f"{self.season} GW{self.gameweek}: "
+        if self.in_or_out == 1:
+            sugg_str += (
+                f"Suggest buying {self.player_id} for gain of {self.points_gain}"
+            )
+        else:
+            sugg_str += (
+                f"Suggest selling {self.player_id} for gain of {self.points_gain}"
+            )
+        return sugg_str
 
 
 class FifaTeamRating(Base):
@@ -278,6 +335,12 @@ class FifaTeamRating(Base):
     mid = Column(Integer, nullable=False)
     ovr = Column(Integer, nullable=False)
 
+    def __str__(self):
+        return (
+            f"{self.team} {self.season} FIFA rating: "
+            f"ovr {self.ovr}, def {self.defn}, mid {self.mid}, att {self.att}"
+        )
+
 
 class Team(Base):
     __tablename__ = "team"
@@ -288,6 +351,9 @@ class Team(Base):
     team_id = Column(
         Integer, nullable=False
     )  # the season-dependent team ID (from alphabetical order)
+
+    def __str__(self):
+        return f"{self.full_name} ({self.name})"
 
 
 class SessionSquad(Base):

--- a/airsenal/framework/squad.py
+++ b/airsenal/framework/squad.py
@@ -99,25 +99,25 @@ class Squad(object):
         # check if constraints are met
         if not self.check_no_duplicate_player(player):
             if self.verbose:
-                print("Already have {} in team".format(player.name))
+                print("Already have {} in team".format(player))
             return False
         if not self.check_num_in_position(player):
             if self.verbose:
                 print(
                     "Unable to add player {} - too many {}".format(
-                        player.name, player.position
+                        player, player.position
                     )
                 )
             return False
         if check_budget and not self.check_cost(player):
             if self.verbose:
-                print("Cannot afford player {}".format(player.name))
+                print("Cannot afford player {}".format(player))
             return False
         if check_team and not self.check_num_per_team(player):
             if self.verbose:
                 print(
                     "Cannot add {} - too many players from {}".format(
-                        player.name, player.team
+                        player, player.team
                     )
                 )
             return False
@@ -194,7 +194,7 @@ class Squad(object):
             print(
                 "Using purchase price as sale price for",
                 player.player_id,
-                player.name,
+                player,
             )
             price_now = price_bought
 

--- a/airsenal/framework/transaction_utils.py
+++ b/airsenal/framework/transaction_utils.py
@@ -59,6 +59,9 @@ def transaction_exists(
     price_in,
     dbsession=session,
 ):
+    """Check whether the transactions related to transferring a player in and out
+    in a gameweek at a specific time already exist in the database.
+    """
     transactions = (
         dbsession.query(Transaction)
         .filter_by(fpl_team_id=fpl_team_id)

--- a/airsenal/framework/transaction_utils.py
+++ b/airsenal/framework/transaction_utils.py
@@ -3,6 +3,7 @@ Functions to help fill the Transaction table, where players are bought and sold,
 hopefully with the correct price.  Needs FPL_TEAM_ID to be set, either via environment
 variable, or a file named FPL_TEAM_ID in airsenal/data/
 """
+from sqlalchemy import or_, and_
 
 from airsenal.framework.schema import Transaction
 from airsenal.framework.utils import (
@@ -31,6 +32,67 @@ def free_hit_used_in_gameweek(gameweek, fpl_team_id=None):
         return 0
 
 
+def count_transactions(season, fpl_team_id, dbsession=session):
+    """Count the number of transactions we have in the database for a given team ID
+    and season.
+    """
+    if fpl_team_id is None:
+        fpl_team_id = fetcher.FPL_TEAM_ID
+
+    transactions = (
+        dbsession.query(Transaction)
+        .filter_by(fpl_team_id=fpl_team_id)
+        .filter_by(season=season)
+        .all()
+    )
+    return len(transactions)
+
+
+def transaction_exists(
+    fpl_team_id,
+    gameweek,
+    season,
+    time,
+    pid_out,
+    price_out,
+    pid_in,
+    price_in,
+    dbsession=session,
+):
+    transactions = (
+        dbsession.query(Transaction)
+        .filter_by(fpl_team_id=fpl_team_id)
+        .filter_by(gameweek=gameweek)
+        .filter_by(season=season)
+        .filter_by(time=time)
+        .filter(
+            or_(
+                and_(
+                    Transaction.player_id == pid_in,
+                    Transaction.price == price_in,
+                    Transaction.bought_or_sold == 1,
+                ),
+                and_(
+                    Transaction.player_id == pid_out,
+                    Transaction.price == price_out,
+                    Transaction.bought_or_sold == -1,
+                ),
+            )
+        )
+        .all()
+    )
+    if len(transactions) == 2:  # row for player bought and player sold
+        return True
+    elif len(transactions) == 0:
+        return False
+    else:
+        raise ValueError(
+            f"Database error: {len(transactions)} transactions in the database with "
+            f"parameters:  fpl_team_id={fpl_team_id}, gameweek={gameweek}, "
+            f"time={time}, pid_in={pid_in}, pid_out={pid_out}. Should be 2."
+        )
+
+
 def add_transaction(
     player_id,
     gameweek,
@@ -40,6 +102,7 @@ def add_transaction(
     tag,
     free_hit,
     fpl_team_id,
+    time,
     dbsession=session,
 ):
     """
@@ -54,6 +117,7 @@ def add_transaction(
         tag=tag,
         free_hit=free_hit,
         fpl_team_id=fpl_team_id,
+        time=time,
     )
     dbsession.add(t)
     dbsession.commit()
@@ -88,8 +152,10 @@ def fill_initial_squad(
         starting_gw += 1
         print(f"Trying gameweek {starting_gw}...")
         init_players = get_players_for_gameweek(starting_gw, fpl_team_id)
-        free_hit = free_hit_used_in_gameweek(starting_gw, fpl_team_id)
+
     print(f"Got starting squad from gameweek {starting_gw}. Adding player data...")
+    free_hit = free_hit_used_in_gameweek(starting_gw, fpl_team_id)
+    time = fetcher.get_event_data()[starting_gw]["deadline"]
     for pid in init_players:
         player_api_id = get_player(pid).fpl_api_id
         first_gw_data = fetcher.get_gameweek_data_for_player(player_api_id, starting_gw)
@@ -108,7 +174,9 @@ def fill_initial_squad(
         else:
             price = first_gw_data[0]["value"]
 
-        add_transaction(pid, 1, 1, price, season, tag, free_hit, fpl_team_id, dbsession)
+        add_transaction(
+            pid, 1, 1, price, season, tag, free_hit, fpl_team_id, time, dbsession
+        )
 
 
 def update_squad(
@@ -127,7 +195,10 @@ def update_squad(
     print("Updating db with squad with fpl_team_id={}".format(fpl_team_id))
     # do we already have the initial squad for this fpl_team_id?
     existing_transfers = (
-        dbsession.query(Transaction).filter_by(fpl_team_id=fpl_team_id).all()
+        dbsession.query(Transaction)
+        .filter_by(fpl_team_id=fpl_team_id)
+        .filter_by(season=season)
+        .all()
     )
     if len(existing_transfers) == 0:
         # need to put the initial squad into the db
@@ -141,34 +212,57 @@ def update_squad(
         api_pid_out = transfer["element_out"]
         pid_out = get_player_from_api_id(api_pid_out).player_id
         price_out = transfer["element_out_cost"]
-        if verbose:
-            print(
-                "Adding transaction: gameweek: {} removing player {} for {}".format(
-                    gameweek, pid_out, price_out
-                )
-            )
-        free_hit = free_hit_used_in_gameweek(gameweek)
-        add_transaction(
-            pid_out,
-            gameweek,
-            -1,
-            price_out,
-            season,
-            tag,
-            free_hit,
-            fpl_team_id,
-            dbsession,
-        )
         api_pid_in = transfer["element_in"]
         pid_in = get_player_from_api_id(api_pid_in).player_id
         price_in = transfer["element_in_cost"]
-        if verbose:
-            print(
-                "Adding transaction: gameweek: {} adding player {} for {}".format(
-                    gameweek, pid_in, price_in
+        time = transfer["time"]
+
+        if not transaction_exists(
+            fpl_team_id,
+            gameweek,
+            season,
+            time,
+            pid_out,
+            price_out,
+            pid_in,
+            price_in,
+            dbsession=dbsession,
+        ):
+            if verbose:
+                print(
+                    "Adding transaction: gameweek: {} removing player {} for {}".format(
+                        gameweek, pid_out, price_out
+                    )
                 )
+            free_hit = free_hit_used_in_gameweek(gameweek)
+            add_transaction(
+                pid_out,
+                gameweek,
+                -1,
+                price_out,
+                season,
+                tag,
+                free_hit,
+                fpl_team_id,
+                time,
+                dbsession,
             )
-        add_transaction(
-            pid_in, gameweek, 1, price_in, season, tag, free_hit, fpl_team_id, dbsession
-        )
-        pass
+
+            if verbose:
+                print(
+                    "Adding transaction: gameweek: {} adding player {} for {}".format(
+                        gameweek, pid_in, price_in
+                    )
+                )
+            add_transaction(
+                pid_in,
+                gameweek,
+                1,
+                price_in,
+                season,
+                tag,
+                free_hit,
+                fpl_team_id,
+                time,
+                dbsession,
+            )

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -190,11 +190,12 @@ def get_current_players(gameweek=None, season=None, fpl_team_id=None, dbsession=
     current_players = []
     transactions = (
         dbsession.query(Transaction)
-        .filter_by(season=season)
+        .order_by(Transaction.gameweek, Transaction.id)
         .filter_by(fpl_team_id=fpl_team_id)
-        .order_by(Transaction.gameweek)
+        .filter_by(free_hit=0)  # free_hit players shouldn't be considered part of squad
         .all()
     )
+
     if len(transactions) == 0:
         #  not updated the transactions table yet
         return []

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -442,7 +442,13 @@ def list_players(
         last_gw = get_last_complete_gameweek_in_db(
             season=CURRENT_SEASON, dbsession=dbsession
         )
-        if gameweek > last_gw:
+        if last_gw is None and gameweek != 1:
+            print(
+                f"WARNING: No complete gameweek in DB for {season} season, "
+                f"returning players from GW1."
+            )
+            gameweek = 1
+        elif last_gw is not None and gameweek > last_gw:
             print(
                 f"WARNING: Incomplete data in DB for GW{gameweek}, "
                 f"returning players from GW{last_gw}."

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -632,11 +632,7 @@ def get_fixtures_for_player(
             if season == CURRENT_SEASON and fixture.gameweek < NEXT_GAMEWEEK:
                 continue
             if verbose:
-                print(
-                    "{} vs {} gameweek {}".format(
-                        fixture.home_team, fixture.away_team, fixture.gameweek
-                    )
-                )
+                print(fixture)
             fixtures.append(fixture)
     return fixtures
 

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -1048,8 +1048,6 @@ def get_recent_playerscore_rows(
     if not dbsession:
         dbsession = session
 
-    if not last_gw:
-        last_gw = NEXT_GAMEWEEK
     # If asking for gameweeks without results in DB, revert to most recent results.
     last_available_gameweek = get_last_complete_gameweek_in_db(
         season=season, dbsession=dbsession
@@ -1058,7 +1056,7 @@ def get_recent_playerscore_rows(
         # e.g. before this season has started
         return None
 
-    if last_gw > last_available_gameweek:
+    if last_gw is None or last_gw > last_available_gameweek:
         last_gw = last_available_gameweek
 
     first_gw = last_gw - num_match_to_use

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -5,7 +5,6 @@ Useful commands to query the db
 from functools import lru_cache
 from operator import itemgetter
 from datetime import datetime, timezone, date
-from dateutil.relativedelta import relativedelta
 from typing import TypeVar
 import dateparser
 import re
@@ -500,7 +499,7 @@ def list_players(
             players.append(p.player)
             prices.append(p.price)
             if verbose and (len(gameweeks) == 1 or order_by != "price"):
-                print(p.player.name, p.team, p.position, p.price)
+                print(p.player, p.team, p.position, p.price)
     if len(gameweeks) > 1 and order_by == "price":
         # Query sorted by gameweek first, so need to do a final sort here to
         # get final price order if more than one gameweek queried.
@@ -694,7 +693,7 @@ def get_player_scores(fixture=None, player=None, dbsession=session):
     """Get player scores for a fixture."""
     if fixture is None and player is None:
         raise ValueError("At least one of fixture and player must be defined")
-    
+
     query = dbsession.query(PlayerScore)
     if fixture is not None:
         query = query.filter(PlayerScore.fixture == fixture)
@@ -703,7 +702,7 @@ def get_player_scores(fixture=None, player=None, dbsession=session):
 
     player_scores = query.all()
     if not player_scores:
-        raise ValueError(f"No scores found for player {player} in fixture {fixture}")
+        return None
 
     if fixture is not None and player is not None:
         if len(player_scores) > 0:

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -438,9 +438,17 @@ def list_players(
     if not dbsession:
         dbsession = session
 
-    # if trying to get players from the future, return current players
-    if season == CURRENT_SEASON and gameweek > NEXT_GAMEWEEK:
-        gameweek = NEXT_GAMEWEEK
+    # if trying to get players from after DB has filled, return most recent players
+    if season == CURRENT_SEASON:
+        last_gw = get_last_complete_gameweek_in_db(
+            season=CURRENT_SEASON, dbsession=dbsession
+        )
+        if gameweek > last_gw:
+            print(
+                f"WARNING: Incomplete data in DB for GW{gameweek}, "
+                f"returning players from GW{last_gw}."
+            )
+            gameweek = last_gw
 
     gameweeks = [gameweek]
     # check if the team (or all teams) play in the specified gameweek, if not

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -16,7 +16,6 @@ from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.schema import (
     Player,
     PlayerAttributes,
-    Result,
     Fixture,
     PlayerScore,
     PlayerPrediction,
@@ -685,12 +684,6 @@ def get_fixtures_for_gameweek(gameweek, season=CURRENT_SEASON, dbsession=session
         .all()
     )
     return [(fixture.home_team, fixture.away_team) for fixture in fixtures]
-
-
-def get_result_for_fixture(fixture, dbsession=session):
-    """Get result for a fixture."""
-    result = dbsession.query(Result).filter_by(fixture=fixture).all()
-    return result
 
 
 def get_player_scores(fixture=None, player=None, dbsession=session):

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -439,21 +439,18 @@ def list_players(
 
     # if trying to get players from after DB has filled, return most recent players
     if season == CURRENT_SEASON:
-        last_gw = get_last_complete_gameweek_in_db(
-            season=CURRENT_SEASON, dbsession=dbsession
+        last_pa = (
+            dbsession.query(PlayerAttributes)
+            .filter_by(season=season)
+            .order_by(PlayerAttributes.gameweek.desc())
+            .first()
         )
-        if last_gw is None and gameweek != 1:
-            print(
-                f"WARNING: No complete gameweek in DB for {season} season, "
-                f"returning players from GW1."
-            )
-            gameweek = 1
-        elif last_gw is not None and gameweek > last_gw:
+        if last_pa and gameweek > last_pa.gameweek:
             print(
                 f"WARNING: Incomplete data in DB for GW{gameweek}, "
-                f"returning players from GW{last_gw}."
+                f"returning players from GW{last_pa.gameweek}."
             )
-            gameweek = last_gw
+            gameweek = last_pa.gameweek
 
     gameweeks = [gameweek]
     # check if the team (or all teams) play in the specified gameweek, if not

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -1200,17 +1200,18 @@ def get_latest_fixture_tag(season=CURRENT_SEASON, dbsession=None):
 
 
 def find_fixture(
-    gameweek,
     team,
     was_home=None,
     other_team=None,
-    kickoff_time=None,
+    gameweek=None,
     season=CURRENT_SEASON,
+    kickoff_time=None,
     dbsession=session,
 ):
-    """Get a fixture given a gameweek, team and optionally whether
-    the team was at home or away, the kickoff time and the other team in the
-    fixture.
+    """Get a fixture given a team and optionally whether the team was at home or away,
+    the season, kickoff time and the other team in the fixture. Only returns the fixture
+    if exactly one is found that matches the input arguments, otherwise raises a
+    ValueError.
     """
     fixture = None
 
@@ -1227,9 +1228,9 @@ def find_fixture(
     else:
         other_team_name = other_team
 
-    query = (
-        dbsession.query(Fixture).filter_by(gameweek=gameweek).filter_by(season=season)
-    )
+    query = dbsession.query(Fixture).filter_by(season=season)
+    if gameweek:
+        query = query.filter_by(gameweek=gameweek)
     if was_home is True:
         query = query.filter_by(home_team=team_name)
     elif was_home is False:
@@ -1260,8 +1261,10 @@ def find_fixture(
         raise ValueError(
             (
                 "No fixture with season={}, gw={}, team_name={}, was_home={}, "
-                "other_team_name={}"
-            ).format(season, gameweek, team_name, was_home, other_team_name)
+                "other_team_name={}, kickoff_time={}"
+            ).format(
+                season, gameweek, team_name, was_home, other_team_name, kickoff_time
+            )
         )
 
     if len(fixtures) == 1:
@@ -1315,11 +1318,11 @@ def get_player_team_from_fixture(
         opponent_was_home = None
 
     fixture = find_fixture(
-        gameweek,
         opponent,
         was_home=opponent_was_home,
-        kickoff_time=kickoff_time,
+        gameweek=gameweek,
         season=season,
+        kickoff_time=kickoff_time,
         dbsession=dbsession,
     )
 

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -326,7 +326,7 @@ def get_free_transfers(gameweek=None, fpl_team_id=None):
     return num_free_transfers
 
 
-def get_gameweek_by_date(date, dbsession=None):
+def get_gameweek_by_date(date, season=CURRENT_SEASON, dbsession=None):
     """
     Use the dates of the fixtures to find the gameweek.
     """
@@ -335,7 +335,10 @@ def get_gameweek_by_date(date, dbsession=None):
         dbsession = session
     if not isinstance(date, datetime):
         date = dateparser.parse(date)
-    fixtures = dbsession.query(Fixture).all()
+    query = dbsession.query(Fixture)
+    if season is not None:
+        query = query.filter_by(season=season)
+    fixtures = query.all()
     for fixture in fixtures:
         try:
             fixture_date = dateparser.parse(fixture.date)
@@ -958,7 +961,7 @@ def get_top_predicted_points(
             print("-" * 25)
 
 
-def get_return_gameweek_from_news(news, dbsession=None):
+def get_return_gameweek_from_news(news, season=CURRENT_SEASON, dbsession=None):
     """Parse news strings from the FPL API for the return date of injured or
     suspended players. If a date is found, determine and return the gameweek it
     corresponds to.
@@ -977,7 +980,9 @@ def get_return_gameweek_from_news(news, dbsession=None):
                 "Failed to parse date from string '{}'".format(return_date)
             )
 
-        return_gameweek = get_gameweek_by_date(return_date, dbsession=dbsession)
+        return_gameweek = get_gameweek_by_date(
+            return_date, season=season, dbsession=dbsession
+        )
         return return_gameweek
 
     return None

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -446,10 +446,11 @@ def list_players(
             .first()
         )
         if last_pa and gameweek > last_pa.gameweek:
-            print(
-                f"WARNING: Incomplete data in DB for GW{gameweek}, "
-                f"returning players from GW{last_pa.gameweek}."
-            )
+            if verbose:
+                print(
+                    f"WARNING: Incomplete data in DB for GW{gameweek}, "
+                    f"returning players from GW{last_pa.gameweek}."
+                )
             gameweek = last_pa.gameweek
 
     gameweeks = [gameweek]

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -701,7 +701,7 @@ def get_player_scores(fixture=None, player=None, dbsession=session):
         return None
 
     if fixture is not None and player is not None:
-        if len(player_scores) > 0:
+        if len(player_scores) > 1:
             raise ValueError(
                 f"More than one score found for player {player} in fixture {fixture}"
             )

--- a/airsenal/scripts/airsenal_run_pipeline.py
+++ b/airsenal/scripts/airsenal_run_pipeline.py
@@ -4,7 +4,8 @@ import multiprocessing
 
 import click
 
-from airsenal import TMPDIR
+from airsenal.framework.db_config import AIrsenalDBFile
+from airsenal.framework.schema import session, Team
 from airsenal.framework.utils import NEXT_GAMEWEEK, fetcher
 
 
@@ -35,21 +36,32 @@ from airsenal.framework.utils import NEXT_GAMEWEEK, fetcher
     required=False,
     help="fpl team id for pipeline run",
 )
+@click.option(
+    "--clean",
+    is_flag=True,
+    help="If set, delete and recreate the AIrsenal database",
+)
 def run_pipeline(
-    num_thread, num_iterations, weeks_ahead, num_free_transfers, fpl_team_id
+    num_thread, num_iterations, weeks_ahead, num_free_transfers, fpl_team_id, clean
 ):
     if fpl_team_id is None:
         fpl_team_id = fetcher.FPL_TEAM_ID
     print("Running for FPL Team ID {}".format(fpl_team_id))
     if not num_thread:
         num_thread = multiprocessing.cpu_count()
-    click.echo("Cleaning database..")
-    clean_database()
-    click.echo("Setting up Database..")
-    setup_database(fpl_team_id)
-    click.echo("Database setup complete..")
+    if clean:
+        click.echo("Cleaning database..")
+        clean_database()
+    if database_is_empty():
+        click.echo("Setting up Database..")
+        setup_database(fpl_team_id)
+        click.echo("Database setup complete..")
+        update_attr = False
+    else:
+        click.echo("Found pre-existing AIrsenal database.")
+        update_attr = True
     click.echo("Updating database..")
-    update_database(fpl_team_id)
+    update_database(fpl_team_id, attr=update_attr)
     click.echo("Database update complete..")
     click.echo("Running prediction..")
     run_prediction(num_thread, weeks_ahead)
@@ -68,13 +80,21 @@ def clean_database():
     """
     Clean up database
     """
-    file_path = "{}/data.db".format(TMPDIR)
     try:
-        if os.path.exists(file_path):
-            os.remove(file_path)
+        if os.path.exists(AIrsenalDBFile):
+            os.remove(AIrsenalDBFile)
     except IOError as exc:
-        click.echo("Error while deleting file {}. Reason:{}".format(file_path, exc))
+        click.echo(
+            "Error while deleting file {}. Reason:{}".format(AIrsenalDBFile, exc)
+        )
         sys.exit(1)
+
+
+def database_is_empty():
+    """
+    Basic check to determine whether the database is empty
+    """
+    return session.query(Team).first() is None
 
 
 def setup_database(fpl_team_id):
@@ -84,11 +104,14 @@ def setup_database(fpl_team_id):
     os.system("airsenal_setup_initial_db --fpl_team_id {}".format(fpl_team_id))
 
 
-def update_database(fpl_team_id):
+def update_database(fpl_team_id, attr=True):
     """
     Update database
     """
-    os.system("airsenal_update_db --noattr --fpl_team_id {}".format(fpl_team_id))
+    if attr:
+        os.system("airsenal_update_db --fpl_team_id {}".format(fpl_team_id))
+    else:
+        os.system("airsenal_update_db --noattr --fpl_team_id {}".format(fpl_team_id))
 
 
 def run_prediction(num_thread, weeks_ahead):

--- a/airsenal/scripts/data_sanity_checks.py
+++ b/airsenal/scripts/data_sanity_checks.py
@@ -158,7 +158,7 @@ def fixture_player_teams(seasons=CHECK_SEASONS, session=session):
                         "{}: {} in player_scores but labelled as playing for {}."
                     ).format(
                         fixture_string(fixture),
-                        score.player.name,
+                        score.player,
                         score.player_team,
                     )
                     print(msg)

--- a/airsenal/scripts/data_sanity_checks.py
+++ b/airsenal/scripts/data_sanity_checks.py
@@ -3,7 +3,6 @@ from airsenal.framework.utils import (
     session,
     CURRENT_SEASON,
     get_fixtures_for_season,
-    get_result_for_fixture,
     get_player_scores,
 )
 from airsenal.framework.schema import PlayerScore
@@ -14,47 +13,12 @@ CHECK_SEASONS = [CURRENT_SEASON] + get_past_seasons(3)
 SEPARATOR = "\n" + ("=" * 50) + "\n"  # used to separate groups of print statements
 
 
-def fixture_string(fixture, result=None):
-    """Get a string with basic info about a fixture.
-
-    Arguments:
-        fixture {SQLAlchemy class object} -- fixture from the database.
-        result {SQLAlchemy class object} -- result from the database. If given
-        returned string contains the match score.
-
-    Returns:
-        [string] -- formatted string with id, season, gameweek, home team and
-        away team.
-    """
-
-    if result:
-        return "{} GW{} {} {}-{} {} (id {})".format(
-            fixture.season,
-            fixture.gameweek,
-            fixture.home_team,
-            result.home_score,
-            result.away_score,
-            fixture.away_team,
-            fixture.fixture_id,
-        )
-
-    else:
-        return "{} GW{} {} vs {} (id {})".format(
-            fixture.season,
-            fixture.gameweek,
-            fixture.home_team,
-            fixture.away_team,
-            fixture.fixture_id,
-        )
-
-
 def result_string(n_error):
     """make string representing check result
 
     Arguments:
         n_error {int} -- number of errors encountered during check
     """
-
     if n_error == 0:
         return "OK!"
     else:
@@ -146,22 +110,23 @@ def fixture_player_teams(seasons=CHECK_SEASONS, session=session):
         fixtures = get_fixtures_for_season(season=season)
 
         for fixture in fixtures:
-            player_scores = get_player_scores(fixture=fixture)
+            if fixture.result:
+                player_scores = get_player_scores(fixture=fixture)
 
-            for score in player_scores:
-                if not (
-                    (score.player_team == fixture.home_team)
-                    or (score.player_team == fixture.away_team)
-                ):
-                    n_error += 1
-                    msg = (
-                        "{}: {} in player_scores but labelled as playing for {}."
-                    ).format(
-                        fixture_string(fixture),
-                        score.player,
-                        score.player_team,
-                    )
-                    print(msg)
+                for score in player_scores:
+                    if not (
+                        (score.player_team == fixture.home_team)
+                        or (score.player_team == fixture.away_team)
+                    ):
+                        n_error += 1
+                        msg = (
+                            "{}: {} in player_scores but labelled as playing for {}."
+                        ).format(
+                            fixture,
+                            score.player,
+                            score.player_team,
+                        )
+                        print(msg)
 
     print("\n", result_string(n_error))
     return n_error
@@ -177,8 +142,10 @@ def fixture_num_players(seasons=CHECK_SEASONS, session=session):
         airsenal.framework.schema.session)
     """
     print(
-        "Checking 11 to 14 players play per team in each fixture "
-        "(with exceptions for 19/20)...\n"
+        "Checking 11 to 14 players play per team in each fixture...\n"
+        "Note:\n"
+        "- 2019/20: 5 subs allowed after Covid-19 lockdown (accounted for in checks)\n"
+        "- From 2020/21: Concussion subs allowed (may cause false errors)\n"
     )
     n_error = 0
 
@@ -186,10 +153,9 @@ def fixture_num_players(seasons=CHECK_SEASONS, session=session):
         fixtures = get_fixtures_for_season(season=season)
 
         for fixture in fixtures:
-            result = get_result_for_fixture(fixture)
+            result = fixture.result
 
             if result:
-                result = result[0]
                 home_scores = (
                     session.query(PlayerScore)
                     .filter_by(fixture=fixture, player_team=fixture.home_team)
@@ -216,7 +182,7 @@ def fixture_num_players(seasons=CHECK_SEASONS, session=session):
                     n_error += 1
                     print(
                         "{}: {} players with minutes > 0 for home team.".format(
-                            fixture_string(fixture, result), len(home_scores)
+                            result, len(home_scores)
                         )
                     )
 
@@ -226,7 +192,7 @@ def fixture_num_players(seasons=CHECK_SEASONS, session=session):
                     n_error += 1
                     print(
                         "{}: {} players with minutes > 0 for away team.".format(
-                            fixture_string(fixture, result), len(away_scores)
+                            result, len(away_scores)
                         )
                     )
 
@@ -249,10 +215,9 @@ def fixture_num_goals(seasons=CHECK_SEASONS, session=session):
         fixtures = get_fixtures_for_season(season=season)
 
         for fixture in fixtures:
-            result = get_result_for_fixture(fixture)
+            result = fixture.result
 
             if result:
-                result = result[0]
                 home_scores = (
                     session.query(PlayerScore)
                     .filter_by(fixture=fixture, player_team=fixture.home_team)
@@ -279,7 +244,7 @@ def fixture_num_goals(seasons=CHECK_SEASONS, session=session):
                         "{}: Player scores sum to {} but {} goals in result "
                         "for home team"
                     ).format(
-                        fixture_string(fixture, result),
+                        result,
                         home_goals,
                         result.home_score,
                     )
@@ -291,7 +256,7 @@ def fixture_num_goals(seasons=CHECK_SEASONS, session=session):
                         "{}: Player scores sum to {} but {} goals in result "
                         "for away team"
                     ).format(
-                        fixture_string(fixture, result),
+                        result,
                         away_goals,
                         result.away_score,
                     )
@@ -319,10 +284,8 @@ def fixture_num_assists(seasons=CHECK_SEASONS, session=session):
         fixtures = get_fixtures_for_season(season=season)
 
         for fixture in fixtures:
-            result = get_result_for_fixture(fixture)
-
+            result = fixture.result
             if result:
-                result = result[0]
                 home_scores = (
                     session.query(PlayerScore)
                     .filter_by(fixture=fixture, player_team=fixture.home_team)
@@ -344,7 +307,7 @@ def fixture_num_assists(seasons=CHECK_SEASONS, session=session):
                         "{}: Player assists sum to {} but {} goals in result "
                         "for home team"
                     ).format(
-                        fixture_string(fixture, result),
+                        result,
                         home_assists,
                         result.home_score,
                     )
@@ -356,7 +319,7 @@ def fixture_num_assists(seasons=CHECK_SEASONS, session=session):
                         "{}: Player assists sum to {} but {} goals in result "
                         "for away team"
                     ).format(
-                        fixture_string(fixture, result),
+                        result,
                         away_assists,
                         result.away_score,
                     )
@@ -384,10 +347,8 @@ def fixture_num_conceded(seasons=CHECK_SEASONS, session=session):
         fixtures = get_fixtures_for_season(season=season)
 
         for fixture in fixtures:
-            result = get_result_for_fixture(fixture)
-
+            result = fixture.result
             if result:
-                result = result[0]
                 home_scores = (
                     session.query(PlayerScore)
                     .filter_by(
@@ -411,7 +372,7 @@ def fixture_num_conceded(seasons=CHECK_SEASONS, session=session):
                     n_error += 1
                     msg = "{}: Player conceded {} but {} goals in result for home team"
                     msg = msg.format(
-                        fixture_string(fixture, result),
+                        result,
                         home_conceded,
                         result.away_score,
                     )
@@ -421,7 +382,7 @@ def fixture_num_conceded(seasons=CHECK_SEASONS, session=session):
                     n_error += 1
                     msg = "{}: Player conceded {} but {} goals in result for away team"
                     msg = msg.format(
-                        fixture_string(fixture, result),
+                        result,
                         away_conceded,
                         result.home_score,
                     )

--- a/airsenal/scripts/data_sanity_checks.py
+++ b/airsenal/scripts/data_sanity_checks.py
@@ -4,7 +4,7 @@ from airsenal.framework.utils import (
     CURRENT_SEASON,
     get_fixtures_for_season,
     get_result_for_fixture,
-    get_player_scores_for_fixture,
+    get_player_scores,
 )
 from airsenal.framework.schema import PlayerScore
 
@@ -146,7 +146,7 @@ def fixture_player_teams(seasons=CHECK_SEASONS, session=session):
         fixtures = get_fixtures_for_season(season=season)
 
         for fixture in fixtures:
-            player_scores = get_player_scores_for_fixture(fixture)
+            player_scores = get_player_scores(fixture=fixture)
 
             for score in player_scores:
                 if not (

--- a/airsenal/scripts/fill_fixture_table.py
+++ b/airsenal/scripts/fill_fixture_table.py
@@ -54,8 +54,10 @@ def fill_fixtures_from_api(season, dbsession=session):
                 other_team=fixture["team_a"],
                 season=season,
             )
+            update = True
         except ValueError:
             f = Fixture()
+            update = False
 
         f.date = fixture["kickoff_time"]
         f.gameweek = fixture["event"]
@@ -86,7 +88,8 @@ def fill_fixtures_from_api(season, dbsession=session):
         else:
             pass
 
-        dbsession.add(f)
+        if not update:
+            dbsession.add(f)
 
     dbsession.commit()
     return True

--- a/airsenal/scripts/fill_fixture_table.py
+++ b/airsenal/scripts/fill_fixture_table.py
@@ -12,7 +12,7 @@ import uuid
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.mappings import alternative_team_names
 from airsenal.framework.schema import Fixture, session_scope, session
-from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
+from airsenal.framework.utils import CURRENT_SEASON, find_fixture, get_past_seasons
 
 
 def fill_fixtures_from_file(filename, season, dbsession=session):
@@ -47,7 +47,15 @@ def fill_fixtures_from_api(season, dbsession=session):
     fetcher = FPLDataFetcher()
     fixtures = fetcher.get_fixture_data()
     for fixture in fixtures:
-        f = Fixture()
+        try:
+            f = find_fixture(
+                fixture["team_h"],
+                was_home=True,
+                other_team=fixture["team_a"],
+                season=season,
+            )
+        except ValueError:
+            f = Fixture()
 
         f.date = fixture["kickoff_time"]
         f.gameweek = fixture["event"]

--- a/airsenal/scripts/fill_fixture_table.py
+++ b/airsenal/scripts/fill_fixture_table.py
@@ -53,6 +53,7 @@ def fill_fixtures_from_api(season, dbsession=session):
                 was_home=True,
                 other_team=fixture["team_a"],
                 season=season,
+                dbsession=dbsession,
             )
             update = True
         except ValueError:

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -177,7 +177,7 @@ def fill_attributes_table_from_api(
                 pa.transfers_in = int(result["transfers_in"])
                 pa.transfers_out = int(result["transfers_out"])
 
-                if update:
+                if not update:
                     # don't need to add to dbsession if updating pre-existing row
                     dbsession.add(pa)
 

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -38,7 +38,7 @@ def fill_attributes_table_from_file(detail_data, season, dbsession=session):
             print("Couldn't find player {}".format(player_name))
             continue
 
-        print("ATTRIBUTES {} {}".format(season, player.name))
+        print("ATTRIBUTES {} {}".format(season, player))
         # now loop through all the fixtures that player played in
         #  Only one attributes row per gameweek - create list of gameweeks
         # encountered so can ignore duplicates (e.g. from double gameweeks).

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -134,6 +134,9 @@ def fill_attributes_table_from_api(
 
         # now get data for previous gameweeks
         player_data = fetcher.get_gameweek_data_for_player(player_api_id)
+        if not player_data:
+            print("Failed to get data for", player.name)
+            continue
         for gameweek, data in player_data.items():
             if gameweek not in range(gw_start, gw_end):
                 continue

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -66,9 +66,7 @@ def fill_attributes_table_from_file(detail_data, season, dbsession=session):
                 dbsession.add(pa)
 
 
-def fill_attributes_table_from_api(
-    season, gw_start=1, dbsession=session
-):
+def fill_attributes_table_from_api(season, gw_start=1, dbsession=session):
     """
     use the FPL API to get player attributes info for the current season
     """

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -124,6 +124,7 @@ def fill_attributes_table_from_api(
         ):
             pa.return_gameweek = get_return_gameweek_from_news(
                 p_summary["news"],
+                season=season,
                 dbsession=dbsession,
             )
 

--- a/airsenal/scripts/fill_player_table.py
+++ b/airsenal/scripts/fill_player_table.py
@@ -11,23 +11,23 @@ from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
 
 
-def find_player_in_table(name, session):
+def find_player_in_table(name, dbsession):
     """
     see if we already have the player
     """
-    player = session.query(Player).filter_by(name=name).first()
+    player = dbsession.query(Player).filter_by(name=name).first()
     return player if player else None
 
 
-def num_players_in_table(session):
+def num_players_in_table(dbsession):
     """
     how many players already in player table
     """
-    players = session.query(Player).all()
+    players = dbsession.query(Player).all()
     return len(players)
 
 
-def fill_player_table_from_file(filename, season, session):
+def fill_player_table_from_file(filename, season, dbsession):
     """
     use json file
     """
@@ -37,7 +37,7 @@ def fill_player_table_from_file(filename, season, session):
         new_entry = False
         name = jp["name"]
         print("PLAYER {} {}".format(season, name))
-        p = find_player_in_table(name, session)
+        p = find_player_in_table(name, dbsession)
         if not p:
             n_new_players += 1
             new_entry = True
@@ -47,11 +47,11 @@ def fill_player_table_from_file(filename, season, session):
             #            )  # next id sequentially
             p.name = name
         if new_entry:
-            session.add(p)
-    session.commit()
+            dbsession.add(p)
+    dbsession.commit()
 
 
-def fill_player_table_from_api(season, session):
+def fill_player_table_from_api(season, dbsession):
     """
     use the FPL API
     """
@@ -67,8 +67,8 @@ def fill_player_table_from_api(season, session):
 
         print("PLAYER {} {}".format(season, name))
         p.name = name
-        session.add(p)
-    session.commit()
+        dbsession.add(p)
+    dbsession.commit()
 
 
 def make_player_table(seasons=[], dbsession=session):
@@ -77,7 +77,7 @@ def make_player_table(seasons=[], dbsession=session):
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
     if CURRENT_SEASON in seasons:
-        fill_player_table_from_api(CURRENT_SEASON, session)
+        fill_player_table_from_api(CURRENT_SEASON, dbsession)
     for season in seasons:
         if season == CURRENT_SEASON:
             continue
@@ -89,7 +89,7 @@ def make_player_table(seasons=[], dbsession=session):
                 "player_summary_{}.json".format(season),
             )
         )
-        fill_player_table_from_file(filename, season, session)
+        fill_player_table_from_file(filename, season, dbsession)
 
 
 if __name__ == "__main__":

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -18,7 +18,7 @@ from airsenal.framework.utils import (
     CURRENT_SEASON,
     find_fixture,
     get_player_team_from_fixture,
-    get_player_scores
+    get_player_scores,
 )
 
 
@@ -61,11 +61,7 @@ def fill_playerscores_from_json(detail_data, season, dbsession=session):
             )
 
             if not fixture or not fixture.result:
-                print(
-                    "  Couldn't find result for {} in gw {}".format(
-                        player, gameweek
-                    )
-                )
+                print("  Couldn't find result for {} in gw {}".format(player, gameweek))
                 continue
             ps = PlayerScore()
             ps.player_team = played_for

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -50,12 +50,12 @@ def fill_playerscores_from_json(detail_data, season, dbsession=session):
                 was_home = None
 
             fixture = find_fixture(
-                gameweek,
                 played_for,
-                other_team=fixture_data["opponent"],
                 was_home=was_home,
-                kickoff_time=fixture_data["kickoff_time"],
+                other_team=fixture_data["opponent"],
+                gameweek=gameweek,
                 season=season,
+                kickoff_time=fixture_data["kickoff_time"],
                 dbsession=dbsession,
             )
 

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -112,15 +112,16 @@ def fill_playerscores_from_json(detail_data, season, dbsession=session):
 def fill_playerscores_from_api(
     season, gw_start=1, gw_end=NEXT_GAMEWEEK, dbsession=session
 ):
-
     fetcher = FPLDataFetcher()
     input_data = fetcher.get_player_summary_data()
     for player_api_id in input_data.keys():
-        # find the player in the player table.  If they're not
-        # there, then we don't care (probably not a current player).
         player = get_player_from_api_id(player_api_id, dbsession=dbsession)
         if not player:
-            print("No player with API id {}".format(player_api_id))
+            # If no player found with this API ID something has gone wrong with the
+            # Player table, e.g. clashes between players with the same name
+            print(f"ERROR! No player with API id {player_api_id}. Skipped.")
+            continue
+
         print("SCORES {} {}".format(season, player.name))
         player_data = fetcher.get_gameweek_data_for_player(player_api_id)
         # now loop through all the matches that player played in

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -59,7 +59,7 @@ def fill_playerscores_from_json(detail_data, season, dbsession=session):
                 dbsession=dbsession,
             )
 
-            if not fixture:
+            if not fixture or not fixture.result:
                 print(
                     "  Couldn't find result for {} in gw {}".format(
                         player.name, gameweek
@@ -142,9 +142,9 @@ def fill_playerscores_from_api(
                     return_fixture=True,
                 )
 
-                if not fixture or not played_for:
+                if not fixture or not played_for or not fixture.result:
                     print(
-                        "  Couldn't find match for {} in gw {}".format(
+                        "  Couldn't find match result for {} in gw {}".format(
                             player.name, gameweek
                         )
                     )

--- a/airsenal/scripts/fill_result_table.py
+++ b/airsenal/scripts/fill_result_table.py
@@ -9,11 +9,10 @@ import argparse
 import os
 
 from airsenal.framework.mappings import alternative_team_names
-from airsenal.framework.schema import Result, session_scope, Fixture, session
+from airsenal.framework.schema import Result, session_scope, session
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.utils import (
     NEXT_GAMEWEEK,
-    get_latest_fixture_tag,
     get_past_seasons,
     find_fixture,
     CURRENT_SEASON,
@@ -37,7 +36,13 @@ def fill_results_from_csv(input_file, season, dbsession):
             elif away_team in v:
                 away_team = k
         # query database to find corresponding fixture
-        f = _find_fixture(season, home_team, away_team, dbsession)
+        f = find_fixture(
+            home_team,
+            was_home=True,
+            other_team=away_team,
+            season=season,
+            dbsession=dbsession,
+        )
         res = Result()
         res.fixture = f
         res.home_score = int(home_score)
@@ -69,7 +74,7 @@ def fill_results_from_api(gw_start, gw_end, season, dbsession):
         if not away_team:
             raise ValueError("Unable to find team with id {}".format(away_id))
         home_score = m["team_h_score"]
-        away_score = m["team_a_score"]    
+        away_score = m["team_a_score"]
         f = find_fixture(
             home_team,
             was_home=True,

--- a/airsenal/scripts/update_db.py
+++ b/airsenal/scripts/update_db.py
@@ -150,7 +150,6 @@ def update_attributes(season, dbsession):
     fill_attributes_table_from_api(
         season=season,
         gw_start=last_in_db,
-        gw_end=NEXT_GAMEWEEK,
         dbsession=dbsession,
     )
 

--- a/airsenal/scripts/update_db.py
+++ b/airsenal/scripts/update_db.py
@@ -108,6 +108,7 @@ def update_players(season, dbsession):
             "Something strange has happened - more players in DB than API"
         )
     else:
+        print("Updating player table...")
         # find the new player(s) from the API
         api_ids_from_db = [p.fpl_api_id for p in players_from_db]
         new_players = [p for p in players_from_api if p not in api_ids_from_db]
@@ -115,13 +116,16 @@ def update_players(season, dbsession):
             first_name = player_data_from_api[player_api_id]["first_name"]
             second_name = player_data_from_api[player_api_id]["second_name"]
             name = "{} {}".format(first_name, second_name)
-            print("Adding player {}".format(name))
             # check whether we alreeady have this player in the database -
             # if yes update that player's data, if no create a new player
             p = get_player(name, dbsession=dbsession)
             if p is None:
+                print("Adding player {}".format(name))
                 p = Player()
                 update = False
+            elif p.fpl_api_id is None:
+                print("Updating player {}".format(name))
+                update = True
             else:
                 update = True
             p.fpl_api_id = player_api_id
@@ -187,6 +191,7 @@ def main():
             update_attributes(season, session)
 
         # update fixtures (which may have been rescheduled)
+        print("Updating fixture table...")
         fill_fixtures_from_api(season, session)
         # update results and playerscores
         update_results(season, session)

--- a/airsenal/scripts/update_db.py
+++ b/airsenal/scripts/update_db.py
@@ -19,6 +19,7 @@ from airsenal.framework.utils import (
     get_player,
 )
 from airsenal.scripts.fill_player_attributes_table import fill_attributes_table_from_api
+from airsenal.scripts.fill_fixture_table import fill_fixtures_from_api
 from airsenal.scripts.fill_result_table import fill_results_from_api
 from airsenal.scripts.fill_playerscore_table import fill_playerscores_from_api
 from airsenal.framework.transaction_utils import update_squad
@@ -182,10 +183,11 @@ def main():
         if not do_attributes and num_new_players > 0:
             print("New players added - enforcing update of attributes table")
             do_attributes = True
-
         if do_attributes:
             update_attributes(season, session)
 
+        # update fixtures (which may have been rescheduled)
+        fill_fixtures_from_api(season, session)
         # update results and playerscores
         update_results(season, session)
         # update our squad


### PR DESCRIPTION
To make it possible to have a persistent database:

- Add fixture updates to `airsenal_update_db` (for #338)
- Fix some logic around updating pre-existing rows and free hit transfers, and skip errors due to duplicate player names.
- Make `airsenal_update_db` faster by modifying `get_gameweek_by_date` to filter fixtures by season and adding a LRU cache (same as the previous contribution to make the optimisation much faster).
- Make it possible to specify the database location in config files.
- Make `airsenal_run_pipeline` only update the database by default (not delete and recreate). Add `--clean` argument to delete and recreate if desired.
-  Fix logic for finding the last gameweek we have all results for.
- Check for pre-existing rows in db when updating match results and player scores.
- Add `__str__` methods to classes in schema to tidy up some printing.
- Fix `list_players` returning an empty list if the database isn't filled up to `NEXT_GAMEWEEK` (return most recent data in the DB instead).
- Fix checks for whether transactions are already in the database when adding them from the API (for #355)