### PR TITLE
Persistent AIrsenal database

### DIFF
--- a/airsenal/framework/db_config.py
+++ b/airsenal/framework/db_config.py
@@ -1,27 +1,68 @@
 """
 Database can be either an sqlite file or a postgress server
 """
-
 import os
 from airsenal import TMPDIR
 
-# Default connection string points to a local sqlite file in
-# airsenal/data/data.db
-
-DB_CONNECTION_STRING = "sqlite:///{}/data.db".format(TMPDIR)
+config_path = os.path.join(os.path.dirname(__file__), "..", "data")
+AIrsenalDBFile_path = os.path.join(config_path, "AIrsenalDBFile")
+AIrsenalDBUri_path = os.path.join(config_path, "AIrsenalDBUri")
+AIrsenalDBUser_path = os.path.join(config_path, "AIrsenalDBUser")
+AIrsenalDBPassword_path = os.path.join(config_path, "AIrsenalDBPassword")
 
 # Check that we're not trying to set location for both sqlite and postgres
-if "AIrsenalDBFile" in os.environ.keys() and "AIrsenalDBUri" in os.environ.keys():
+if ("AIrsenalDBFile" in os.environ.keys() or os.path.exists(AIrsenalDBFile_path)) and (
+    "AIrsenalDBUri" in os.environ.keys() or os.path.exists(AIrsenalDBUri_path)
+):
     raise RuntimeError("Please choose only ONE of AIrsenalDBFile and AIrsenalDBUri")
 
-# location of sqlite file overridden by an env var
+# sqlite database in a local file with path specified by:
+# - AIrsenalDBFile environment variable
+# - airsenal/data/AIrsenalDBFile file
+# - platform-dependent temporary directory (default)
 if "AIrsenalDBFile" in os.environ.keys():
-    DB_CONNECTION_STRING = "sqlite:///{}".format(os.environ["AIrsenalDBFile"])
+    AIrsenalDBFile = os.environ["AIrsenalDBFile"]
+elif os.path.exists(AIrsenalDBFile_path):
+    AIrsenalDBFile = open(AIrsenalDBFile_path).read().strip()
+else:
+    AIrsenalDBFile = os.path.join(TMPDIR, "data.db")
 
-# location of postgres server
-if "AIrsenalDBUri" in os.environ.keys():
+DB_CONNECTION_STRING = "sqlite:///{}".format(AIrsenalDBFile)
+
+# postgres database specified by: AIrsenalDBUri, AIrsenalDBUser, AIrsenalDBPassword
+# defined either as:
+# - environment variables
+# - Files in airsenal/data/
+if "AIrsenalDBUri" in os.environ.keys() or os.path.exists(AIrsenalDBUri_path):
+    if "AIrsenalDBUser" in os.environ.keys():
+        AIrsenalDBUser = os.environ["AIrsenalDBUser"]
+    elif os.path.exists(AIrsenalDBUser_path):
+        AIrsenalDBUser = open(AIrsenalDBUser_path).read().strip()
+    else:
+        raise RuntimeError(
+            "AIrsenalDBUser must be defined when using a postgres database"
+        )
+
+    if "AIrsenalDBUser" in os.environ.keys():
+        AIrsenalDBPassword = os.environ["AIrsenalDBPassword"]
+    elif os.path.exists(AIrsenalDBPassword_path):
+        AIrsenalDBPassword = open(AIrsenalDBPassword_path).read().strip()
+    else:
+        raise RuntimeError(
+            "AIrsenalDBPassword must be defined when using a postgres database"
+        )
+
+    if "AIrsenalDBUri" in os.environ.keys():
+        AIrsenalDBUri = os.environ["AIrsenalDBUri"]
+    elif os.path.exists(AIrsenalDBUri_path):
+        AIrsenalDBUri = open(AIrsenalDBUri_path).read().strip()
+    else:
+        raise RuntimeError(
+            "AIrsenalDBUri must be defined when using a postgres database"
+        )
+
     DB_CONNECTION_STRING = "postgres://{}:{}@{}/airsenal".format(
-        os.environ["AIrsenalDBUser"],
-        os.environ["AIrsenalDBPassword"],
-        os.environ["AIrsenalDBUri"],
+        AIrsenalDBUser,
+        AIrsenalDBPassword,
+        AIrsenalDBUri,
     )

--- a/airsenal/scripts/airsenal_run_pipeline.py
+++ b/airsenal/scripts/airsenal_run_pipeline.py
@@ -56,8 +56,14 @@ def run_pipeline(
         click.echo("Setting up Database..")
         setup_database(fpl_team_id)
         click.echo("Database setup complete..")
+        setup_database = True
+    else:
+        setup_database = False
     click.echo("Updating database..")
-    update_database(fpl_team_id)
+    if setup_database:
+        update_database(fpl_team_id, attr=False)
+    else:
+        update_database(fpl_team_id, attr=True)
     click.echo("Database update complete..")
     click.echo("Running prediction..")
     run_prediction(num_thread, weeks_ahead)
@@ -100,11 +106,14 @@ def setup_database(fpl_team_id):
     os.system("airsenal_setup_initial_db --fpl_team_id {}".format(fpl_team_id))
 
 
-def update_database(fpl_team_id):
+def update_database(fpl_team_id, attr=True):
     """
     Update database
     """
-    os.system("airsenal_update_db --noattr --fpl_team_id {}".format(fpl_team_id))
+    if attr:
+        os.system("airsenal_update_db --fpl_team_id {}".format(fpl_team_id))
+    else:
+        os.system("airsenal_update_db --noattr --fpl_team_id {}".format(fpl_team_id))
 
 
 def run_prediction(num_thread, weeks_ahead):

--- a/airsenal/scripts/airsenal_run_pipeline.py
+++ b/airsenal/scripts/airsenal_run_pipeline.py
@@ -56,14 +56,12 @@ def run_pipeline(
         click.echo("Setting up Database..")
         setup_database(fpl_team_id)
         click.echo("Database setup complete..")
-        setup_database = True
+        update_attr = False
     else:
-        setup_database = False
+        click.echo("Found pre-existing AIrsenal database.")
+        update_attr = True
     click.echo("Updating database..")
-    if setup_database:
-        update_database(fpl_team_id, attr=False)
-    else:
-        update_database(fpl_team_id, attr=True)
+    update_database(fpl_team_id, attr=update_attr)
     click.echo("Database update complete..")
     click.echo("Running prediction..")
     run_prediction(num_thread, weeks_ahead)


### PR DESCRIPTION
Changes to make it easier to run AIrsenal with a persistent database rather than a temporary one:
- Add environment variables or config files to specify database location.
- Make `airsenal_run_pipeline` only update the database by default, rather than deleting and recreating. Added `--clean` argument for delete/recreate behaviour (and initial setup will be run if database file doesn't exist or the `Team` table is empty).