### PR TITLE
Fix pystan version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,8 @@ channels:
 dependencies:
   - python=3.7
   - pip
-  - pystan
+  - pystan=2.19.1.1
   - pygmo
   - pip:
     - .
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["cython", "numpy", "pystan","setuptools"]
+requires = ["cython", "numpy", "pystan~=2.19.1.1",  "setuptools"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scipy
 pip
 pystan~=2.19.1.1
 pytest
-bpl==0.0.4
+bpl==0.1.1
 flask
 flask_cors
 flask_session

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dateparser
 matplotlib
 scipy
 pip
-pystan>=2.14
+pystan~=2.19.1.1
 pytest
 bpl==0.0.4
 flask


### PR DESCRIPTION
The version of pystan on pypi just changed to 3.x, which has breaking changes. In order to avoid them, this PR pins the pystan version in requirements.txt to the most recent 2.x.

**Question**: I've set the base branch as develop, but since this is a hotfix, should I change it to master?