### PR TITLE
multiprocessing fix

### DIFF
--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -26,7 +26,7 @@ import warnings
 import cProfile
 
 
-from multiprocessing import Process
+from multiprocessing import Process, set_start_method
 from tqdm import tqdm, TqdmWarning
 import argparse
 
@@ -666,6 +666,13 @@ def main():
             "same input gameweeks and season you specified here.",
         )
         sys.exit(1)
+    
+    # to fix change of default behaviour in multiprocessing on Python 3.8 and later
+    # on Windows and OSX. Python 3.8 and later start processess using spawn by default
+    # see https://docs.python.org/3.8/library/multiprocessing.html#contexts-and-start-methods
+	
+    set_start_method("fork")
+    
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", TqdmWarning)
         run_optimization(


### PR DESCRIPTION
This works at least on my Python 3.9 setup on M1 silicon MacBook.
Please verify on earlier Python versions.
I noticed that after running
`airsenal_run_optimization --weeks_ahead 3`
and completing the task, the status bar is not correctly refreshed.
Upon running one can see multiple status bars and follow progress, but after completion I get this:
Total progress:   7%|██                          | 1/14 [01:20<17:21, 80.14s/it]
