### PR TITLE
Discord web-hook development #403

### DIFF
--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -33,8 +33,11 @@ class FPLDataFetcher(object):
         self.fpl_team_data = {}  # players in squad, by gameweek
         self.fixture_data = None
         for ID in [
-            "FPL_LEAGUE_ID", "FPL_TEAM_ID", "FPL_LOGIN",
-            "FPL_PASSWORD", "DISCORD_WEBHOOK"
+            "FPL_LEAGUE_ID",
+            "FPL_TEAM_ID",
+            "FPL_LOGIN",
+            "FPL_PASSWORD",
+            "DISCORD_WEBHOOK",
         ]:
             if ID in os.environ.keys():
                 self.__setattr__(ID, os.environ[ID])

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -32,7 +32,10 @@ class FPLDataFetcher(object):
         self.fpl_league_data = None
         self.fpl_team_data = {}  # players in squad, by gameweek
         self.fixture_data = None
-        for ID in ["FPL_LEAGUE_ID", "FPL_TEAM_ID", "FPL_LOGIN", "FPL_PASSWORD", "DISCORD_WEBHOOK"]:
+        for ID in [
+            "FPL_LEAGUE_ID", "FPL_TEAM_ID", "FPL_LOGIN",
+            "FPL_PASSWORD", "DISCORD_WEBHOOK"
+        ]:
             if ID in os.environ.keys():
                 self.__setattr__(ID, os.environ[ID])
             elif os.path.exists(

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -32,7 +32,7 @@ class FPLDataFetcher(object):
         self.fpl_league_data = None
         self.fpl_team_data = {}  # players in squad, by gameweek
         self.fixture_data = None
-        for ID in ["FPL_LEAGUE_ID", "FPL_TEAM_ID", "FPL_LOGIN", "FPL_PASSWORD"]:
+        for ID in ["FPL_LEAGUE_ID", "FPL_TEAM_ID", "FPL_LOGIN", "FPL_PASSWORD", "DISCORD_WEBHOOK"]:
             if ID in os.environ.keys():
                 self.__setattr__(ID, os.environ[ID])
             elif os.path.exists(

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -926,21 +926,25 @@ def get_top_predicted_points(
             )
         
         # If a valid discord webhook URL has been stored in env variables, send a webhook message
-        if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
-            payload = get_discord_payload(
-                            discord_embed=discord_embed,
-                            position=position,
-                            pts=pts[:n_players],
-                            season=season,
-                            first_gw=first_gw
-                        )
-            result = requests.post(discord_webhook, json=payload)
-            if 200 <= result.status_code < 300:
-                print(f"Webhook sent {result.status_code}")
+        if discord_webhook != "MISSING_ID":
+        # Use regex to check the discord webhook url is correctly formatted
+            if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
+                # Maximum fields on a discord embed is 25, so limit this to n_players=8
+                payload = predicted_points_discord_payload(
+                                discord_embed=discord_embed,
+                                position=position,
+                                pts=pts[:min(n_players,8)],
+                                season=season,
+                                first_gw=first_gw
+                            )
+                result = requests.post(discord_webhook, json=payload)
+                if 200 <= result.status_code < 300:
+                    print(f"Discord webhook sent, status code: {result.status_code}")
+                else:
+                    print(f"Not sent with {result.status_code}, response:\n{result.json()}")
             else:
-                print(f"Not sent with {result.status_code}, response:\n{result.json()}")
-        else:
-            print("Warning: Discord webhook url is malformed!\n", discord_webhook)
+                #TODO make this so it won't warn if the variable isn't set
+                print("Warning: Discord webhook url is malformed!\n", discord_webhook)
 
     else:
         for position in ["GK", "DEF", "MID", "FWD"]:
@@ -969,30 +973,41 @@ def get_top_predicted_points(
                     )
                 )
             print("-" * 25)
-            # If a valid discord webhook URL has been stored in env variables, send a webhook message
-            if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
-                payload = get_discord_payload(
-                                discord_embed=discord_embed,
-                                position=position,
-                                pts=pts[:n_players],
-                                season=season,
-                                first_gw=first_gw
-                            )
-                result = requests.post(discord_webhook, json=payload)
-                if 200 <= result.status_code < 300:
-                    print(f"Webhook sent {result.status_code}")
-                else:
-                    print(f"Not sent with {result.status_code}, response:\n{result.json()}")
-            else:
-                print("Warning: Discord webhook url is malformed!\n", discord_webhook)
 
-def get_discord_payload(
+            discord_embed['fields'] = []
+            # If a valid discord webhook URL has been stored in env variables, send a webhook message
+            if discord_webhook != "MISSING_ID":
+                # Use regex to check the discord webhook url is correctly formatted
+                if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
+                # create a formatted team lineup message for the discord webhook
+                    # Maximum fields on a discord embed is 25, so limit this to n_players=8
+                    payload = predicted_points_discord_payload(
+                                    discord_embed=discord_embed,
+                                    position=position,
+                                    pts=pts[:min(n_players,8)],
+                                    season=season,
+                                    first_gw=first_gw
+                                )
+                    result = requests.post(discord_webhook, json=payload)
+                    if 200 <= result.status_code < 300:
+                        print(f"Discord webhook sent, status code: {result.status_code}")
+                    else:
+                        print(f"Not sent with {result.status_code}, response:\n{result.json()}")
+                else:
+                    #TODO make this so it won't warn if the variable isn't set
+                    print("Warning: Discord webhook url is malformed!\n", discord_webhook)
+
+
+def predicted_points_discord_payload(
     discord_embed, 
     position, 
     pts, 
     season, 
     first_gw
 ):
+    """
+    json formated discord webhook contentent.
+    """
     discord_embed['fields'].append(
         {
             "name": 'Position',

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -7,7 +7,7 @@ from operator import itemgetter
 from datetime import datetime, timezone, date
 from typing import TypeVar
 import dateparser
-import re
+import regex as re
 from pickle import loads, dumps
 import requests
 from sqlalchemy import or_, case, desc
@@ -931,8 +931,8 @@ def get_top_predicted_points(
         if discord_webhook != "MISSING_ID":
             # Use regex to check the discord webhook url is correctly formatted
             if re.match(
-                '^.*(discord|discordapp)\.com\/api'
-                '\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
+                r'^.*(discord|discordapp)\.com\/api'
+                r'\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
                 discord_webhook
             ):
                 # Maximum fields on a discord embed is 25, so limit this to n_players=8
@@ -986,8 +986,8 @@ def get_top_predicted_points(
             if discord_webhook != "MISSING_ID":
                 # Use regex to check the discord webhook url is correctly formatted
                 if re.match(
-                    '^.*(discord|discordapp)\.com\/api'
-                    '\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
+                    r'^.*(discord|discordapp)\.com\/api'
+                    r'\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
                     discord_webhook
                 ):
                     # create a formatted team lineup message for the discord webhook

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -890,8 +890,8 @@ def get_top_predicted_points(
         "title": "AIrsenal webhook",
         "description": "PREDICTED TOP {} "
         "PLAYERS FOR GAMEWEEK(S) {}:".format(n_players, gameweek),
-        "color": 0x35a800,
-        "fields": []
+        "color": 0x35A800,
+        "fields": [],
     }
 
     first_gw = gameweek[0] if isinstance(gameweek, (list, tuple)) else gameweek
@@ -931,24 +931,26 @@ def get_top_predicted_points(
         if discord_webhook != "MISSING_ID":
             # Use regex to check the discord webhook url is correctly formatted
             if re.match(
-                r'^.*(discord|discordapp)\.com\/api'
-                r'\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
-                discord_webhook
+                r"^.*(discord|discordapp)\.com\/api"
+                r"\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$",
+                discord_webhook,
             ):
                 # Maximum fields on a discord embed is 25, so limit this to n_players=8
                 payload = predicted_points_discord_payload(
-                                discord_embed=discord_embed,
-                                position=position,
-                                pts=pts[:min(n_players, 8)],
-                                season=season,
-                                first_gw=first_gw
-                            )
+                    discord_embed=discord_embed,
+                    position=position,
+                    pts=pts[: min(n_players, 8)],
+                    season=season,
+                    first_gw=first_gw,
+                )
                 result = requests.post(discord_webhook, json=payload)
                 if 200 <= result.status_code < 300:
                     print(f"Discord webhook sent, status code: {result.status_code}")
                 else:
-                    print(f"Not sent with {result.status_code},"
-                          "response:\n{result.json()}")
+                    print(
+                        f"Not sent with {result.status_code},"
+                        "response:\n{result.json()}"
+                    )
             else:
                 print("Warning: Discord webhook url is malformed!\n", discord_webhook)
 
@@ -980,75 +982,63 @@ def get_top_predicted_points(
                 )
             print("-" * 25)
 
-            discord_embed['fields'] = []
+            discord_embed["fields"] = []
             # If a valid discord webhook URL has been stored
             # in env variables, send a webhook message
             if discord_webhook != "MISSING_ID":
                 # Use regex to check the discord webhook url is correctly formatted
                 if re.match(
-                    r'^.*(discord|discordapp)\.com\/api'
-                    r'\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
-                    discord_webhook
+                    r"^.*(discord|discordapp)\.com\/api"
+                    r"\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$",
+                    discord_webhook,
                 ):
                     # create a formatted team lineup message for the discord webhook
                     # Maximum fields on a discord embed is 25
                     # limit this to n_players=8
                     payload = predicted_points_discord_payload(
-                                    discord_embed=discord_embed,
-                                    position=position,
-                                    pts=pts[:min(n_players, 8)],
-                                    season=season,
-                                    first_gw=first_gw
-                                )
+                        discord_embed=discord_embed,
+                        position=position,
+                        pts=pts[: min(n_players, 8)],
+                        season=season,
+                        first_gw=first_gw,
+                    )
                     result = requests.post(discord_webhook, json=payload)
                     if 200 <= result.status_code < 300:
                         print(
                             f"Discord webhook sent, status code: {result.status_code}"
-                            )
+                        )
                     else:
                         print(
                             f"Not sent with {result.status_code}, "
                             f"response:\n{result.json()}"
-                            )
+                        )
                 else:
-                    print("Warning: Discord webhook url is malformed!\n",
-                          discord_webhook)
+                    print(
+                        "Warning: Discord webhook url is malformed!\n", discord_webhook
+                    )
 
 
-def predicted_points_discord_payload(
-    discord_embed,
-    position,
-    pts,
-    season,
-    first_gw
-):
+def predicted_points_discord_payload(discord_embed, position, pts, season, first_gw):
     """
     json formated discord webhook contentent.
     """
-    discord_embed['fields'].append(
-        {
-            "name": 'Position',
-            "value": str(position),
-            "inline": False
-        }
+    discord_embed["fields"].append(
+        {"name": "Position", "value": str(position), "inline": False}
     )
     for i, p in enumerate(pts):
-        discord_embed['fields'].extend(
+        discord_embed["fields"].extend(
             [
                 {
                     "name": "Player",
-                    "value": "{}. {}".format(
-                        i + 1,
-                        p[0].name
-                    ),
-                    "inline": True
+                    "value": "{}. {}".format(i + 1, p[0].name),
+                    "inline": True,
                 },
                 {
                     "name": "Predicted points",
                     "value": "{:.2f}pts".format(
                         p[1],
                     ),
-                    "inline": True
+                    "inline": True,
                 },
                 {
                     "name": "Attributes",
@@ -1057,16 +1047,14 @@ def predicted_points_discord_payload(
                         p[0].position(season),
                         p[0].team(season, first_gw),
                     ),
-                    "inline": True
-                }
+                    "inline": True,
+                },
             ]
         )
     payload = {
         "content": "",
         "username": "AIrsenal",
-        "embeds": [
-            discord_embed
-        ],
+        "embeds": [discord_embed],
     }
     return payload
 

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -888,7 +888,8 @@ def get_top_predicted_points(
 
     discord_embed = {
         "title": "AIrsenal webhook",
-        "description": "PREDICTED TOP {} PLAYERS FOR GAMEWEEK(S) {}:".format(n_players, gameweek),
+        "description": "PREDICTED TOP {} "
+        "PLAYERS FOR GAMEWEEK(S) {}:".format(n_players, gameweek),
         "color": 0x35a800,
         "fields": []
     }
@@ -924,16 +925,21 @@ def get_top_predicted_points(
                     p[0].team(season, first_gw),
                 )
             )
-        
-        # If a valid discord webhook URL has been stored in env variables, send a webhook message
+
+        # If a valid discord webhook URL has been stored
+        # in env variables, send a webhook message
         if discord_webhook != "MISSING_ID":
-        # Use regex to check the discord webhook url is correctly formatted
-            if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
+            # Use regex to check the discord webhook url is correctly formatted
+            if re.match(
+                '^.*(discord|discordapp)\.com\/api'
+                '\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
+                discord_webhook
+            ):
                 # Maximum fields on a discord embed is 25, so limit this to n_players=8
                 payload = predicted_points_discord_payload(
                                 discord_embed=discord_embed,
                                 position=position,
-                                pts=pts[:min(n_players,8)],
+                                pts=pts[:min(n_players, 8)],
                                 season=season,
                                 first_gw=first_gw
                             )
@@ -941,9 +947,9 @@ def get_top_predicted_points(
                 if 200 <= result.status_code < 300:
                     print(f"Discord webhook sent, status code: {result.status_code}")
                 else:
-                    print(f"Not sent with {result.status_code}, response:\n{result.json()}")
+                    print(f"Not sent with {result.status_code},"
+                          "response:\n{result.json()}")
             else:
-                #TODO make this so it won't warn if the variable isn't set
                 print("Warning: Discord webhook url is malformed!\n", discord_webhook)
 
     else:
@@ -975,34 +981,45 @@ def get_top_predicted_points(
             print("-" * 25)
 
             discord_embed['fields'] = []
-            # If a valid discord webhook URL has been stored in env variables, send a webhook message
+            # If a valid discord webhook URL has been stored
+            # in env variables, send a webhook message
             if discord_webhook != "MISSING_ID":
                 # Use regex to check the discord webhook url is correctly formatted
-                if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
-                # create a formatted team lineup message for the discord webhook
-                    # Maximum fields on a discord embed is 25, so limit this to n_players=8
+                if re.match(
+                    '^.*(discord|discordapp)\.com\/api'
+                    '\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
+                    discord_webhook
+                ):
+                    # create a formatted team lineup message for the discord webhook
+                    # Maximum fields on a discord embed is 25
+                    # limit this to n_players=8
                     payload = predicted_points_discord_payload(
                                     discord_embed=discord_embed,
                                     position=position,
-                                    pts=pts[:min(n_players,8)],
+                                    pts=pts[:min(n_players, 8)],
                                     season=season,
                                     first_gw=first_gw
                                 )
                     result = requests.post(discord_webhook, json=payload)
                     if 200 <= result.status_code < 300:
-                        print(f"Discord webhook sent, status code: {result.status_code}")
+                        print(
+                            f"Discord webhook sent, status code: {result.status_code}"
+                            )
                     else:
-                        print(f"Not sent with {result.status_code}, response:\n{result.json()}")
+                        print(
+                            f"Not sent with {result.status_code}, "
+                            f"response:\n{result.json()}"
+                            )
                 else:
-                    #TODO make this so it won't warn if the variable isn't set
-                    print("Warning: Discord webhook url is malformed!\n", discord_webhook)
+                    print("Warning: Discord webhook url is malformed!\n",
+                          discord_webhook)
 
 
 def predicted_points_discord_payload(
-    discord_embed, 
-    position, 
-    pts, 
-    season, 
+    discord_embed,
+    position,
+    pts,
+    season,
     first_gw
 ):
     """

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -359,15 +359,21 @@ def discord_payload(strat, lineup):
                 "inline": False
             }
         )
-        for i in range(len(strat["players_in"][str(gw)])):
-            pin = get_player_name(strat["players_in"][str(gw)][i])
-            pout = get_player_name(strat["players_out"][str(gw)][i])
-            discord_embed['fields'].append(
+        pin = [get_player_name(p) for p in strat["players_in"][str(gw)]]
+        pout = [get_player_name(p) for p in strat["players_out"][str(gw)]]
+        discord_embed['fields'].extend(
+                [
                     {
-                        "name": "GW{} transfer {}:".format(gw, i),
-                        "value": "out: {}\nin:{}".format(pin, pout),
+                        "name": "GW{} transfers out:".format(gw),
+                        "value": "{}".format('\n'.join(pout)),
+                        "inline": True
+                    },
+                    {
+                        "name": "GW{} transfers in:".format(gw),
+                        "value": "{}".format('\n'.join(pin)),
                         "inline": True
                     }
+                ]
             )
     payload = {
         "content": '\n'.join(lineup),
@@ -581,7 +587,7 @@ def run_optimization(
                             player_line += "(VC)"
                         lineup_strings.append(player_line)
                 lineup_strings.append("```\n")
-            lineup_strings.append("=== **subs** ===")
+            lineup_strings.append("__subs__")
             lineup_strings.append("```")
             subs = [p for p in t.players if not p.is_starting]
             subs.sort(key=lambda p: p.sub_position)

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -346,8 +346,8 @@ def discord_payload(strat, lineup):
     gameweeks_as_int = sorted([int(gw) for gw in gameweeks_as_str])
     discord_embed = {
         "title": "AIrsenal webhook",
-        "description": "Optimum strategy for gameweek(S) "\
-        "{}:".format(','.join(str(x) for x in gameweeks_as_int)),
+        "description": "Optimum strategy for gameweek(S)"
+        " {}:".format(','.join(str(x) for x in gameweeks_as_int)),
         "color": 0x35a800,
         "fields": []
     }
@@ -555,11 +555,15 @@ def run_optimization(
     print_strat(best_strategy)
     t = print_team_for_next_gw(best_strategy, fpl_team_id)
 
-    # If a valid discord webhook URL has been stored in env variables, send a webhook message
+    # If a valid discord webhook URL has been stored
+    # in env variables, send a webhook message
     if discord_webhook != "MISSING_ID":
         # Use regex to check the discord webhook url is correctly formatted
-        if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
-             # create a formatted team lineup message for the discord webhook
+        if re.match(
+            '^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
+            discord_webhook
+        ):
+            # create a formatted team lineup message for the discord webhook
             lineup_strings = [
                 "__Strategy for Team ID: **{}**__".format(fpl_team_id),
                 "Baseline score: *{}*".format(int(baseline_score)),
@@ -569,13 +573,13 @@ def run_optimization(
             for position in ["GK", "DEF", "MID", "FWD"]:
                 lineup_strings.append("== **{}** ==\n```".format(position))
                 for p in t.players:
-                        if p.position == position and p.is_starting:
-                            player_line = "{} ({})".format(p.name, p.team)
-                            if p.is_captain:
-                                player_line += "(C)"
-                            elif p.is_vice_captain:
-                                player_line += "(VC)"
-                            lineup_strings.append(player_line)
+                    if p.position == position and p.is_starting:
+                        player_line = "{} ({})".format(p.name, p.team)
+                        if p.is_captain:
+                            player_line += "(C)"
+                        elif p.is_vice_captain:
+                            player_line += "(VC)"
+                        lineup_strings.append(player_line)
                 lineup_strings.append("```\n")
             lineup_strings.append("=== **subs** ===")
             lineup_strings.append("```")

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -18,7 +18,7 @@ representing 0, 1, 2 transfers for the next gameweek.
 
 
 import os
-import re
+import regex as re
 import shutil
 import time
 import json
@@ -566,7 +566,7 @@ def run_optimization(
     if discord_webhook != "MISSING_ID":
         # Use regex to check the discord webhook url is correctly formatted
         if re.match(
-            '^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
+            r'^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
             discord_webhook
         ):
             # create a formatted team lineup message for the discord webhook

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -347,40 +347,38 @@ def discord_payload(strat, lineup):
     discord_embed = {
         "title": "AIrsenal webhook",
         "description": "Optimum strategy for gameweek(S)"
-        " {}:".format(','.join(str(x) for x in gameweeks_as_int)),
-        "color": 0x35a800,
-        "fields": []
+        " {}:".format(",".join(str(x) for x in gameweeks_as_int)),
+        "color": 0x35A800,
+        "fields": [],
     }
     for gw in gameweeks_as_int:
-        discord_embed['fields'].append(
+        discord_embed["fields"].append(
             {
                 "name": "GW{} chips:".format(gw),
                 "value": "Chips played:  {}\n".format(strat["chips_played"][str(gw)]),
-                "inline": False
+                "inline": False,
             }
         )
         pin = [get_player_name(p) for p in strat["players_in"][str(gw)]]
         pout = [get_player_name(p) for p in strat["players_out"][str(gw)]]
-        discord_embed['fields'].extend(
-                [
-                    {
-                        "name": "GW{} transfers out:".format(gw),
-                        "value": "{}".format('\n'.join(pout)),
-                        "inline": True
-                    },
-                    {
-                        "name": "GW{} transfers in:".format(gw),
-                        "value": "{}".format('\n'.join(pin)),
-                        "inline": True
-                    }
-                ]
-            )
+        discord_embed["fields"].extend(
+            [
+                {
+                    "name": "GW{} transfers out:".format(gw),
+                    "value": "{}".format("\n".join(pout)),
+                    "inline": True,
+                },
+                {
+                    "name": "GW{} transfers in:".format(gw),
+                    "value": "{}".format("\n".join(pin)),
+                    "inline": True,
+                },
+            ]
+        )
     payload = {
-        "content": '\n'.join(lineup),
+        "content": "\n".join(lineup),
         "username": "AIrsenal",
-        "embeds": [
-            discord_embed
-        ],
+        "embeds": [discord_embed],
     }
     return payload
 
@@ -566,8 +564,8 @@ def run_optimization(
     if discord_webhook != "MISSING_ID":
         # Use regex to check the discord webhook url is correctly formatted
         if re.match(
-            r'^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$',
-            discord_webhook
+            r"^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$",
+            discord_webhook,
         ):
             # create a formatted team lineup message for the discord webhook
             lineup_strings = [

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -18,6 +18,7 @@ representing 0, 1, 2 transfers for the next gameweek.
 
 
 import os
+import re
 import shutil
 import time
 import json
@@ -27,6 +28,7 @@ import cProfile
 
 
 from multiprocessing import Process
+import requests
 from tqdm import tqdm, TqdmWarning
 import argparse
 
@@ -336,6 +338,47 @@ def print_strat(strat):
     print(" Total score: {} \n".format(int(strat["total_score"])))
 
 
+def discord_payload(strat, lineup):
+    """
+    json formated discord webhook contentent.
+    """
+    gameweeks_as_str = strat["points_per_gw"].keys()
+    gameweeks_as_int = sorted([int(gw) for gw in gameweeks_as_str])
+    discord_embed = {
+        "title": "AIrsenal webhook",
+        "description": "Optimum strategy for gameweek(S) "\
+        "{}:".format(','.join(str(x) for x in gameweeks_as_int)),
+        "color": 0x35a800,
+        "fields": []
+    }
+    for gw in gameweeks_as_int:
+        discord_embed['fields'].append(
+            {
+                "name": "GW{} chips:".format(gw),
+                "value": "Chips played:  {}\n".format(strat["chips_played"][str(gw)]),
+                "inline": False
+            }
+        )
+        for i in range(len(strat["players_in"][str(gw)])):
+            pin = get_player_name(strat["players_in"][str(gw)][i])
+            pout = get_player_name(strat["players_out"][str(gw)][i])
+            discord_embed['fields'].append(
+                    {
+                        "name": "GW{} transfer {}:".format(gw, i),
+                        "value": "out: {}\nin:{}".format(pin, pout),
+                        "inline": True
+                    }
+            )
+    payload = {
+        "content": '\n'.join(lineup),
+        "username": "AIrsenal",
+        "embeds": [
+            discord_embed
+        ],
+    }
+    return payload
+
+
 def print_team_for_next_gw(strat, fpl_team_id=None):
     """
     Display the team (inc. subs and captain) for the next gameweek
@@ -351,6 +394,7 @@ def print_team_for_next_gw(strat, fpl_team_id=None):
     tag = get_latest_prediction_tag()
     t.get_expected_points(next_gw, tag)
     print(t)
+    return t
 
 
 def run_optimization(
@@ -375,6 +419,7 @@ def run_optimization(
     is not to be played, 0 for 'play it any week', or the gw in which
     it should be played.
     """
+    discord_webhook = fetcher.DISCORD_WEBHOOK
     if fpl_team_id is None:
         fpl_team_id = fetcher.FPL_TEAM_ID
 
@@ -508,7 +553,47 @@ def run_optimization(
     print("Baseline score: {}".format(baseline_score))
     print("Best score: {}".format(best_strategy["total_score"]))
     print_strat(best_strategy)
-    print_team_for_next_gw(best_strategy, fpl_team_id)
+    t = print_team_for_next_gw(best_strategy, fpl_team_id)
+
+    # If a valid discord webhook URL has been stored in env variables, send a webhook message
+    if discord_webhook != "MISSING_ID":
+        # Use regex to check the discord webhook url is correctly formatted
+        if re.match('^.*(discord|discordapp)\.com\/api\/webhooks\/([\d]+)\/([a-zA-Z0-9_-]+)$', discord_webhook):
+             # create a formatted team lineup message for the discord webhook
+            lineup_strings = [
+                "__Strategy for Team ID: **{}**__".format(fpl_team_id),
+                "Baseline score: *{}*".format(int(baseline_score)),
+                "Best score: *{}*".format(int(best_strategy["total_score"])),
+                "\n__starting 11__",
+            ]
+            for position in ["GK", "DEF", "MID", "FWD"]:
+                lineup_strings.append("== **{}** ==\n```".format(position))
+                for p in t.players:
+                        if p.position == position and p.is_starting:
+                            player_line = "{} ({})".format(p.name, p.team)
+                            if p.is_captain:
+                                player_line += "(C)"
+                            elif p.is_vice_captain:
+                                player_line += "(VC)"
+                            lineup_strings.append(player_line)
+                lineup_strings.append("```\n")
+            lineup_strings.append("=== **subs** ===")
+            lineup_strings.append("```")
+            subs = [p for p in t.players if not p.is_starting]
+            subs.sort(key=lambda p: p.sub_position)
+            for p in subs:
+                lineup_strings.append("{} ({})".format(p.name, p.team))
+            lineup_strings.append("```\n")
+
+            # generate a discord embed json and send to webhook
+            payload = discord_payload(best_strategy, lineup_strings)
+            result = requests.post(discord_webhook, json=payload)
+            if 200 <= result.status_code < 300:
+                print(f"Discord webhook sent, status code: {result.status_code}")
+            else:
+                print(f"Not sent with {result.status_code}, response:\n{result.json()}")
+        else:
+            print("Warning: Discord webhook url is malformed!\n", discord_webhook)
     shutil.rmtree(OUTPUT_DIR, ignore_errors=True)
     return
 


### PR DESCRIPTION
Added support for optionally sending the output from AIrsenal optimisation to a [discord webhook](https://discord.com/developers/docs/resources/webhook) #403. Uses the env variable or data file DISCORD_WEBHOOK which should contain the discord web hook URL as generated.  

Tested and working with Discord version: 1.0.9002 (08/09/2021)

Tested with a valid webhook url, an invalid url and no environment variable set. 