### PR TITLE
Automating create a new release when develop merged to main

### DIFF
--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Bump version and push tag
         id: tag_version
         uses: anothrNick/github-tag-action@1.36.0

--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -2,7 +2,7 @@ name: Increase tag and generated release
 on:
   push:
     branches:
-      - Automatic_release
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: '0'
       - name: Bump version and push tag
         id: tag_version
         uses: anothrNick/github-tag-action@1.36.0

--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -2,7 +2,7 @@ name: Increase tag and generated release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/automatic_release.yml
+++ b/.github/workflows/automatic_release.yml
@@ -1,0 +1,22 @@
+name: Increase tag and generated release
+on:
+  push:
+    branches:
+      - Automatic_release
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version and push tag
+        id: tag_version
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
This new workflow tries to solve the #439. It automatically bump the tag version with a patch v0.0.1 -> v0.0.2 and generate the release for that version every time something is pushed to main.

It uses the custom action:

[anothrNick/github-tag-action](https://github.com/anothrNick/github-tag-action)

**NOTE**
![Screenshot 2021-10-19 at 15 02 07](https://user-images.githubusercontent.com/6976921/137914787-1cc28c40-1efa-40d8-a171-5c6038a150dd.png)

So we can manage the version by using
` #major` , ` #minor` , ` #patch` or by tagging the `HEAD` 

I already tried on my fork, on a different branch


