### PR TITLE
Adding functionality to airsenal_setup_initial_db

### DIFF
--- a/airsenal/framework/season.py
+++ b/airsenal/framework/season.py
@@ -4,6 +4,7 @@ Season details
 
 """
 from datetime import datetime
+from typing import List
 
 from airsenal.framework.schema import Team, session
 
@@ -36,3 +37,38 @@ def get_teams_for_season(season, dbsession):
 
 # global variable for the module
 CURRENT_TEAMS = get_teams_for_season(CURRENT_SEASON, session)
+
+
+def season_str_to_year(season: str) -> int:
+    """Convert season in "1819" format to the year the season started (2018)
+
+    Parameters
+    ----------
+    season : str
+        Season string in "1819" format (for 2018/19 season)
+
+    Returns
+    -------
+    int
+        Year season started
+    """
+    return int(f"20{season[:2]}")
+
+
+def sort_seasons(seasons: List[str], desc: bool = True) -> List[str]:
+    """_summary_
+
+    Parameters
+    ----------
+    seasons : List[str]
+        List of seasons strings in "1819" formrat (for 2018/19 season)
+
+    desc : bool , optional
+        If True, sort from most recent season to oldest. By default True.
+
+    Returns
+    -------
+    List[str]
+        Seasons sorted in chronological order (by default from most recent to oldest)
+    """
+    return sorted(seasons, key=season_str_to_year, reverse=desc)

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -110,6 +110,8 @@ def get_next_gameweek(season=CURRENT_SEASON, dbsession=None) -> int:
 
 @lru_cache(365)
 def parse_datetime(check_date) -> datetime:
+    if not check_date:
+        return None
     if type(check_date) is datetime:
         return check_date
     if isinstance(check_date, str):

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -139,7 +139,7 @@ def get_next_gameweek_by_date(check_date, season=CURRENT_SEASON, dbsession=None)
 
     if len(fixtures) > 0:
         for fixture in fixtures:
-            if not fixture:
+            if not fixture.date:
                 # date could be null if fixture not scheduled
                 continue
             fixture_date = parse_date(fixture.date)
@@ -151,7 +151,7 @@ def get_next_gameweek_by_date(check_date, season=CURRENT_SEASON, dbsession=None)
 
         # now make sure we aren't in the middle of a gameweek
         for fixture in fixtures:
-            if not fixture:
+            if not fixture.date:
                 # date could be null if fixture not scheduled
                 continue
             if (

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -113,12 +113,16 @@ def get_next_gameweek(season=CURRENT_SEASON, dbsession=None) -> int:
 
 @lru_cache(365)
 def parse_datetime(check_date) -> datetime:
+    if not check_date:
+        return None
     if type(check_date) is datetime:
         return check_date
-    try:
-        return isoparse(check_date)
-    except (ValueError, TypeError):
-        return dateparser.parse(check_date)
+    if isinstance(check_date, str):
+        try:
+            return isoparse(check_date)
+        except (ValueError, TypeError):
+            return dateparser.parse(check_date)
+    raise TypeError(f"Don't know what to do with type {type(check_date)}")
 
 
 @lru_cache(365)

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -110,8 +110,6 @@ def get_next_gameweek(season=CURRENT_SEASON, dbsession=None) -> int:
 
 @lru_cache(365)
 def parse_datetime(check_date) -> datetime:
-    if not check_date:
-        return None
     if type(check_date) is datetime:
         return check_date
     if isinstance(check_date, str):

--- a/airsenal/scripts/fill_absence_table.py
+++ b/airsenal/scripts/fill_absence_table.py
@@ -5,7 +5,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from airsenal.framework.schema import Absence, session
-from airsenal.framework.season import CURRENT_SEASON
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
 from airsenal.framework.utils import (
     get_next_gameweek_by_date,
     get_past_seasons,
@@ -119,7 +119,7 @@ def load_suspensions(season, dbsession):
 
 
 def make_absence_table(seasons=get_past_seasons(3), dbsession=session):
-    for season in seasons:
+    for season in sort_seasons(seasons):
         if season == CURRENT_SEASON:
             continue
         load_injuries(season, dbsession)

--- a/airsenal/scripts/fill_absence_table.py
+++ b/airsenal/scripts/fill_absence_table.py
@@ -28,7 +28,7 @@ def load_injuries(season, dbsession):
             print(f"Couldn't find player {row['player']}")
             continue
         date_from = row["from"].date()
-        date_until = None if row["until"].isna() else row["until"].date()
+        date_until = None if row["until"] is pd.NaT else row["until"].date()
         gw_from = get_next_gameweek_by_date(date_from, season, dbsession)
         gw_until = (
             get_next_gameweek_by_date(date_until, season, dbsession)
@@ -80,7 +80,8 @@ def load_suspensions(season, dbsession):
             print(f"Couldn't find player {row['player']}")
             continue
         date_from = row["from"].date()
-        date_until = row["until"].date() if isinstance(row["until"], str) else None
+        date_until = None if row["until"] is pd.NaT else row["until"].date()
+
         gw_from = get_next_gameweek_by_date(date_from, season, dbsession)
         gw_until = (
             get_next_gameweek_by_date(date_until, season, dbsession)

--- a/airsenal/scripts/fill_absence_table.py
+++ b/airsenal/scripts/fill_absence_table.py
@@ -5,6 +5,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from airsenal.framework.schema import Absence, session
+from airsenal.framework.season import CURRENT_SEASON
 from airsenal.framework.utils import (
     get_next_gameweek_by_date,
     get_past_seasons,
@@ -119,5 +120,7 @@ def load_suspensions(season, dbsession):
 
 def make_absence_table(seasons=get_past_seasons(3), dbsession=session):
     for season in seasons:
+        if season == CURRENT_SEASON:
+            continue
         load_injuries(season, dbsession)
         load_suspensions(season, dbsession)

--- a/airsenal/scripts/fill_absence_table.py
+++ b/airsenal/scripts/fill_absence_table.py
@@ -28,9 +28,7 @@ def load_injuries(season, dbsession):
             print(f"Couldn't find player {row['player']}")
             continue
         date_from = row["from"].date()
-        date_until = (
-            row["until"].date() if isinstance(row["until"], pd.Timestamp) else None
-        )
+        date_until = None if row["until"].isna() else row["until"].date()
         gw_from = get_next_gameweek_by_date(date_from, season, dbsession)
         gw_until = (
             get_next_gameweek_by_date(date_until, season, dbsession)

--- a/airsenal/scripts/fill_db_init.py
+++ b/airsenal/scripts/fill_db_init.py
@@ -2,7 +2,7 @@
 import argparse
 
 from airsenal.framework.schema import clean_database, database_is_empty, session_scope
-from airsenal.framework.season import CURRENT_SEASON
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
 from airsenal.framework.transaction_utils import fill_initial_squad
 from airsenal.framework.utils import get_past_seasons
 from airsenal.scripts.fill_absence_table import make_absence_table
@@ -27,6 +27,7 @@ def check_clean_db(clean, dbsession):
 
 
 def make_init_db(fpl_team_id, seasons, dbsession):
+    seasons = sort_seasons(seasons)
     make_team_table(seasons=seasons, dbsession=dbsession)
     make_fixture_table(seasons=seasons, dbsession=dbsession)
     make_result_table(seasons=seasons, dbsession=dbsession)

--- a/airsenal/scripts/fill_db_init.py
+++ b/airsenal/scripts/fill_db_init.py
@@ -67,17 +67,19 @@ def main():
         required=False,
     )
     parser.add_argument(
-        "--inc_current", help="If set, includes CURRENT_SEASON", action="store_true"
+        "--no_current_season",
+        help="If set, does not include CURRENT_SEASON in database",
+        action="store_true",
     )
     args = parser.parse_args()
 
     with session_scope() as dbsession:
         continue_setup = check_clean_db(args.clean, dbsession)
         if continue_setup:
-            if args.inc_current:
-                seasons = [CURRENT_SEASON] + get_past_seasons(args.n_previous)
-            else:
+            if args.no_current_season:
                 seasons = get_past_seasons(args.n_previous)
+            else:
+                seasons = [CURRENT_SEASON] + get_past_seasons(args.n_previous)
             make_init_db(args.fpl_team_id, seasons, dbsession)
         else:
             print(

--- a/airsenal/scripts/fill_db_init.py
+++ b/airsenal/scripts/fill_db_init.py
@@ -61,9 +61,9 @@ def main():
     )
     parser.add_argument(
         "--n_previous",
-        help="specify how many seasons to look back into the past for",
+        help="specify how many seasons to look back into the past for (defaults to 3)",
         type=int,
-        choices=range(1, 6),
+        choices=range(1, 7),
         default=3,
         required=False,
     )

--- a/airsenal/scripts/fill_db_init.py
+++ b/airsenal/scripts/fill_db_init.py
@@ -62,7 +62,8 @@ def main():
     parser.add_argument(
         "--n_previous",
         help="specify how many seasons to look back into the past for",
-        type=check_positive_int,
+        type=int,
+        choices=range(1, 6),
         default=3,
         required=False,
     )

--- a/airsenal/scripts/fill_fifa_ratings_table.py
+++ b/airsenal/scripts/fill_fifa_ratings_table.py
@@ -17,9 +17,8 @@ def make_fifa_ratings_table(seasons=[], dbsession=session):
     # TODO: scrape the data first rather than committing file to repo
 
     if not seasons:
-        seasons = get_past_seasons(3)
-        seasons.append(CURRENT_SEASON)
-
+        seasons = [CURRENT_SEASON]
+        seasons += get_past_seasons(3)
     for season in seasons:
         print(f"FIFA RATINGS {season}")
         input_path = os.path.join(

--- a/airsenal/scripts/fill_fifa_ratings_table.py
+++ b/airsenal/scripts/fill_fifa_ratings_table.py
@@ -9,7 +9,8 @@ import os
 
 from airsenal.framework.mappings import alternative_team_names
 from airsenal.framework.schema import FifaTeamRating, session, session_scope
-from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
+from airsenal.framework.utils import get_past_seasons
 
 
 def make_fifa_ratings_table(seasons=[], dbsession=session):
@@ -19,7 +20,7 @@ def make_fifa_ratings_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    for season in seasons:
+    for season in sort_seasons(seasons):
         print(f"FIFA RATINGS {season}")
         input_path = os.path.join(
             os.path.dirname(__file__), f"../data/fifa_team_ratings_{season}.csv"

--- a/airsenal/scripts/fill_fixture_table.py
+++ b/airsenal/scripts/fill_fixture_table.py
@@ -11,7 +11,8 @@ import uuid
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.mappings import alternative_team_names
 from airsenal.framework.schema import Fixture, session, session_scope
-from airsenal.framework.utils import CURRENT_SEASON, find_fixture, get_past_seasons
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
+from airsenal.framework.utils import find_fixture, get_past_seasons
 
 
 def fill_fixtures_from_file(filename, season, dbsession=session):
@@ -96,7 +97,7 @@ def make_fixture_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    for season in seasons:
+    for season in sort_seasons(seasons):
         if season == CURRENT_SEASON:
             # current season - use API
             fill_fixtures_from_api(CURRENT_SEASON, dbsession=dbsession)

--- a/airsenal/scripts/fill_fixture_table.py
+++ b/airsenal/scripts/fill_fixture_table.py
@@ -13,8 +13,6 @@ from airsenal.framework.mappings import alternative_team_names
 from airsenal.framework.schema import Fixture, session, session_scope
 from airsenal.framework.utils import CURRENT_SEASON, find_fixture, get_past_seasons
 
-# from tkinter import CURRENT
-
 
 def fill_fixtures_from_file(filename, season, dbsession=session):
     """

--- a/airsenal/scripts/fill_fixture_table.py
+++ b/airsenal/scripts/fill_fixture_table.py
@@ -13,6 +13,8 @@ from airsenal.framework.mappings import alternative_team_names
 from airsenal.framework.schema import Fixture, session, session_scope
 from airsenal.framework.utils import CURRENT_SEASON, find_fixture, get_past_seasons
 
+# from tkinter import CURRENT
+
 
 def fill_fixtures_from_file(filename, season, dbsession=session):
     """
@@ -94,17 +96,20 @@ def fill_fixtures_from_api(season, dbsession=session):
 def make_fixture_table(seasons=[], dbsession=session):
     # fill the fixture table for past seasons
     if not seasons:
-        seasons = get_past_seasons(3)
+        seasons = [CURRENT_SEASON]
+        seasons += get_past_seasons(3)
     for season in seasons:
-        filename = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "data",
-            f"results_{season}_with_gw.csv",
-        )
-        fill_fixtures_from_file(filename, season, dbsession=dbsession)
-    # now fill the current season from the api
-    fill_fixtures_from_api(CURRENT_SEASON, dbsession=dbsession)
+        if season == CURRENT_SEASON:
+            # current season - use API
+            fill_fixtures_from_api(CURRENT_SEASON, dbsession=dbsession)
+        else:
+            filename = os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "data",
+                f"results_{season}_with_gw.csv",
+            )
+            fill_fixtures_from_file(filename, season, dbsession=dbsession)
 
 
 if __name__ == "__main__":

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -187,25 +187,22 @@ def make_attributes_table(seasons=[], dbsession=session):
     player details JSON files) and the current season (from API)
     """
     if not seasons:
-        seasons = get_past_seasons(3)
-        seasons.append(CURRENT_SEASON)
-
+        seasons = [CURRENT_SEASON]
+        seasons += get_past_seasons(3)
     for season in seasons:
         if season == CURRENT_SEASON:
-            continue
-        input_path = os.path.join(
-            os.path.dirname(__file__), f"../data/player_details_{season}.json"
-        )
-        with open(input_path, "r") as f:
-            input_data = json.load(f)
+            # current season - use API
+            fill_attributes_table_from_api(season=CURRENT_SEASON, dbsession=dbsession)
+        else:
+            input_path = os.path.join(
+                os.path.dirname(__file__), f"../data/player_details_{season}.json"
+            )
+            with open(input_path, "r") as f:
+                input_data = json.load(f)
 
-        fill_attributes_table_from_file(
-            detail_data=input_data, season=season, dbsession=dbsession
-        )
-
-    # this season's data from the API
-    if CURRENT_SEASON in seasons:
-        fill_attributes_table_from_api(season=CURRENT_SEASON, dbsession=dbsession)
+            fill_attributes_table_from_file(
+                detail_data=input_data, season=season, dbsession=dbsession
+            )
 
     dbsession.commit()
 

--- a/airsenal/scripts/fill_player_attributes_table.py
+++ b/airsenal/scripts/fill_player_attributes_table.py
@@ -9,8 +9,8 @@ import os
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.mappings import positions
 from airsenal.framework.schema import PlayerAttributes, session, session_scope
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
 from airsenal.framework.utils import (
-    CURRENT_SEASON,
     get_next_gameweek,
     get_past_seasons,
     get_player,
@@ -189,7 +189,7 @@ def make_attributes_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    for season in seasons:
+    for season in sort_seasons(seasons):
         if season == CURRENT_SEASON:
             # current season - use API
             fill_attributes_table_from_api(season=CURRENT_SEASON, dbsession=dbsession)

--- a/airsenal/scripts/fill_player_table.py
+++ b/airsenal/scripts/fill_player_table.py
@@ -8,7 +8,8 @@ import os
 
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.schema import Player, PlayerMapping, session, session_scope
-from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
+from airsenal.framework.utils import get_past_seasons
 from airsenal.scripts.fill_player_mappings_table import (
     add_mappings,
     make_player_mappings_table,
@@ -84,12 +85,8 @@ def make_player_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    if CURRENT_SEASON in seasons:
-        latest_season = CURRENT_SEASON
-    else:
-        latest_season = seasons[0]
-
-    make_init_player_table(season=latest_season, dbsession=session)
+    seasons = sort_seasons(seasons)
+    make_init_player_table(season=seasons[0], dbsession=session)
     make_player_mappings_table(dbsession=session)
     make_remaining_player_table(seasons=seasons[1:], dbsession=session)
 

--- a/airsenal/scripts/fill_player_table.py
+++ b/airsenal/scripts/fill_player_table.py
@@ -9,8 +9,7 @@ import os
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.schema import Player, PlayerMapping, session, session_scope
 from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
-from airsenal.scripts.fill_player_mappings_table import (
-    add_mappings,
+from airsenal.scripts.fill_player_mappings_table import (  # add_mappings,
     make_player_mappings_table,
 )
 
@@ -55,7 +54,7 @@ def fill_player_table_from_file(filename, season, dbsession):
             p.name = name
         if new_entry:
             dbsession.add(p)
-            add_mappings(p, dbsession=dbsession)
+            # add_mappings(p, dbsession=dbsession)
             dbsession.commit()
     dbsession.commit()
 
@@ -84,11 +83,10 @@ def make_player_table(seasons=None, dbsession=session):
     if seasons is None:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-
     if CURRENT_SEASON in seasons:
         latest_season = CURRENT_SEASON
     else:
-        latest_season = seasons[-1]
+        latest_season = seasons[0]
     seasons.remove(latest_season)
 
     make_init_player_table(season=latest_season, dbsession=session)
@@ -102,6 +100,7 @@ def make_init_player_table(season, dbsession=session):
     mappings)
     """
     if season == CURRENT_SEASON:
+        # current season - use API
         fill_player_table_from_api(CURRENT_SEASON, dbsession)
     else:
         filename = os.path.join(

--- a/airsenal/scripts/fill_player_table.py
+++ b/airsenal/scripts/fill_player_table.py
@@ -88,11 +88,10 @@ def make_player_table(seasons=[], dbsession=session):
         latest_season = CURRENT_SEASON
     else:
         latest_season = seasons[0]
-    seasons.remove(latest_season)
 
     make_init_player_table(season=latest_season, dbsession=session)
     make_player_mappings_table(dbsession=session)
-    make_remaining_player_table(seasons=seasons, dbsession=session)
+    make_remaining_player_table(seasons=seasons[1:], dbsession=session)
 
 
 def make_init_player_table(season, dbsession=session):

--- a/airsenal/scripts/fill_player_table.py
+++ b/airsenal/scripts/fill_player_table.py
@@ -9,7 +9,8 @@ import os
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.schema import Player, PlayerMapping, session, session_scope
 from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
-from airsenal.scripts.fill_player_mappings_table import (  # add_mappings,
+from airsenal.scripts.fill_player_mappings_table import (
+    add_mappings,
     make_player_mappings_table,
 )
 
@@ -54,7 +55,7 @@ def fill_player_table_from_file(filename, season, dbsession):
             p.name = name
         if new_entry:
             dbsession.add(p)
-            # add_mappings(p, dbsession=dbsession)
+            add_mappings(p, dbsession=dbsession)
             dbsession.commit()
     dbsession.commit()
 
@@ -79,8 +80,8 @@ def fill_player_table_from_api(season, dbsession):
     dbsession.commit()
 
 
-def make_player_table(seasons=None, dbsession=session):
-    if seasons is None:
+def make_player_table(seasons=[], dbsession=session):
+    if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
     if CURRENT_SEASON in seasons:

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -203,19 +203,18 @@ def fill_playerscores_from_api(
 def make_playerscore_table(seasons=[], dbsession=session):
     # previous seasons data from json files
     if not seasons:
-        seasons = get_past_seasons(3)
-        seasons.append(CURRENT_SEASON)
+        seasons = [CURRENT_SEASON]
+        seasons += get_past_seasons(3)
     for season in seasons:
         if season == CURRENT_SEASON:
-            continue
-        input_path = os.path.join(
-            os.path.dirname(__file__), f"../data/player_details_{season}.json"
-        )
-        input_data = json.load(open(input_path))
-        fill_playerscores_from_json(input_data, season, dbsession=dbsession)
-    # this season's data from the API
-    if CURRENT_SEASON in seasons:
-        fill_playerscores_from_api(CURRENT_SEASON, dbsession=dbsession)
+            # current season - use API
+            fill_playerscores_from_api(CURRENT_SEASON, dbsession=dbsession)
+        else:
+            input_path = os.path.join(
+                os.path.dirname(__file__), f"../data/player_details_{season}.json"
+            )
+            input_data = json.load(open(input_path))
+            fill_playerscores_from_json(input_data, season, dbsession=dbsession)
 
 
 if __name__ == "__main__":

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -9,8 +9,8 @@ import os
 
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.schema import PlayerScore, session, session_scope
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
 from airsenal.framework.utils import (
-    CURRENT_SEASON,
     NEXT_GAMEWEEK,
     find_fixture,
     get_past_seasons,
@@ -205,7 +205,7 @@ def make_playerscore_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    for season in seasons:
+    for season in sort_seasons(seasons):
         if season == CURRENT_SEASON:
             # current season - use API
             fill_playerscores_from_api(CURRENT_SEASON, dbsession=dbsession)

--- a/airsenal/scripts/fill_result_table.py
+++ b/airsenal/scripts/fill_result_table.py
@@ -11,12 +11,8 @@ import os
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.mappings import alternative_team_names
 from airsenal.framework.schema import Result, session, session_scope
-from airsenal.framework.utils import (
-    CURRENT_SEASON,
-    NEXT_GAMEWEEK,
-    find_fixture,
-    get_past_seasons,
-)
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
+from airsenal.framework.utils import NEXT_GAMEWEEK, find_fixture, get_past_seasons
 
 
 def fill_results_from_csv(input_file, season, dbsession):
@@ -104,7 +100,7 @@ def make_result_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    for season in seasons:
+    for season in sort_seasons(seasons):
         if season == CURRENT_SEASON:
             # current season - use API
             gw_end = NEXT_GAMEWEEK

--- a/airsenal/scripts/fill_result_table.py
+++ b/airsenal/scripts/fill_result_table.py
@@ -102,18 +102,19 @@ def make_result_table(seasons=[], dbsession=session):
     past seasons - read results from csv
     """
     if not seasons:
-        seasons = get_past_seasons(3)
+        seasons = [CURRENT_SEASON]
+        seasons += get_past_seasons(3)
     for season in seasons:
-        inpath = os.path.join(
-            os.path.dirname(__file__), f"../data/results_{season}_with_gw.csv"
-        )
-        infile = open(inpath)
-        fill_results_from_csv(infile, season, dbsession)
-    """
-    current season - use API
-    """
-    gw_end = NEXT_GAMEWEEK
-    fill_results_from_api(1, gw_end, CURRENT_SEASON, dbsession)
+        if season == CURRENT_SEASON:
+            # current season - use API
+            gw_end = NEXT_GAMEWEEK
+            fill_results_from_api(1, gw_end, CURRENT_SEASON, dbsession)
+        else:
+            inpath = os.path.join(
+                os.path.dirname(__file__), f"../data/results_{season}_with_gw.csv"
+            )
+            infile = open(inpath)
+            fill_results_from_csv(infile, season, dbsession)
 
 
 if __name__ == "__main__":

--- a/airsenal/scripts/fill_team_table.py
+++ b/airsenal/scripts/fill_team_table.py
@@ -33,10 +33,9 @@ def make_team_table(seasons=[], dbsession=session):
     Fill the db table containing the list of teams in the
     league for each season.
     """
-
     if not seasons:
         seasons = [CURRENT_SEASON]
-        seasons += get_past_seasons(4)
+        seasons += get_past_seasons(3)
     for season in seasons:
         filename = os.path.join(
             os.path.join(os.path.dirname(__file__), "..", "data", f"teams_{season}.csv")

--- a/airsenal/scripts/fill_team_table.py
+++ b/airsenal/scripts/fill_team_table.py
@@ -7,7 +7,8 @@ help fill other tables from raw json files
 import os
 
 from airsenal.framework.schema import Team, session, session_scope
-from airsenal.framework.utils import CURRENT_SEASON, get_past_seasons
+from airsenal.framework.season import CURRENT_SEASON, sort_seasons
+from airsenal.framework.utils import get_past_seasons
 
 
 def fill_team_table_from_file(filename, dbsession=session):
@@ -36,7 +37,7 @@ def make_team_table(seasons=[], dbsession=session):
     if not seasons:
         seasons = [CURRENT_SEASON]
         seasons += get_past_seasons(3)
-    for season in seasons:
+    for season in sort_seasons(seasons):
         filename = os.path.join(
             os.path.join(os.path.dirname(__file__), "..", "data", f"teams_{season}.csv")
         )

--- a/airsenal/scripts/scrape_transfermarkt.py
+++ b/airsenal/scripts/scrape_transfermarkt.py
@@ -12,7 +12,7 @@ import requests
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
-from airsenal.framework.season import CURRENT_SEASON
+from airsenal.framework.season import CURRENT_SEASON, season_str_to_year
 
 TRANSFERMARKT_URL = "https://www.transfermarkt.co.uk"
 HEADERS = {
@@ -196,22 +196,6 @@ def get_players_for_season(season: int) -> List[Tuple[str, str]]:
     for _, team_url in tqdm(teams):
         players.update(get_team_players(team_url))
     return list(players)
-
-
-def season_str_to_year(season: str) -> int:
-    """Convert season in "1819" format to the year the season started (2018)
-
-    Parameters
-    ----------
-    season : str
-        Season string in "1819" format (for 2018/19 season)
-
-    Returns
-    -------
-    int
-        Year season started
-    """
-    return int(f"20{season[:2]}")
 
 
 def get_season_injuries_suspensions(season: str) -> Tuple[pd.DataFrame, pd.DataFrame]:

--- a/airsenal/tests/test_season.py
+++ b/airsenal/tests/test_season.py
@@ -1,0 +1,11 @@
+from airsenal.framework.season import season_str_to_year, sort_seasons
+
+
+def test_season_str_to_year():
+    assert season_str_to_year("1819") == 2018
+
+
+def test_sort_seasons():
+    seasons = ["1819", "2021", "2122", "1920"]
+    assert sort_seasons(seasons) == ["2122", "2021", "1920", "1819"]
+    assert sort_seasons(seasons, desc=False) == ["1819", "1920", "2021", "2122"]


### PR DESCRIPTION
To address #513. Also added `--no_current_season` parser argument to determine whether or not to include `CURRENT_SEASON` which typically relies on pulling data from the various APIs - could be useful for replaying seasons.

Merged with `add-historic-absences` branch to add in new functions to create injuries and suspensions data.

Closes #513 