### PR TITLE
Feature/warn wildcard transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ airsenal_make_squad --num_gameweeks 3
 
 To apply the transfers recommended by AIrsenal to your team on the FPL website run `airsenal_make_transfers`. This can't be undone! You can also use `airsenal_set_lineup` to set your starting lineup, captaincy choices, and substitute order to AIrsenal's recommendation (without making any transfers). Note that you must have created the `FPL_LOGIN` and `FPL_PASSWORD` files for these to work (as described in the "Configuration" section above).
 
+Also note that this command can't currently apply chips such as "free hit" or "wildcard", even if those were specified in the `airsenal_run_optimization` step.  If you do want to use this command to apply the transfers anyway, you can play the chip at any time before the gameweek deadline via the FPL website.
+
 ### Run the Full AIrsenal Pipeline
 
 Instead of running the commands above individually you can use:

--- a/airsenal/scripts/make_transfers.py
+++ b/airsenal/scripts/make_transfers.py
@@ -31,11 +31,18 @@ TODO:
 """
 
 
-def check_proceed() -> bool:
+def check_proceed(num_transfers: int = 0) -> bool:
     proceed = input("Apply Transfers? There is no turning back! (yes/no)")
     if proceed != "yes":
         return False
-
+    if num_transfers > 2:
+        proceed = input(
+            "Note that this script doesn't currently apply wildcard/free-hit chips.\n"
+            "These transfers will result in points hit unless you play one of those "
+            "chips via the website.  Are you sure you wish to proceed? (yes/no) "
+        )
+        if proceed != "yes":
+            return False
     print("Applying Transfers...")
     return True
 
@@ -319,11 +326,14 @@ def make_transfers(
             post_transfer_bank,
         )
 
-    if skip_check or check_proceed():
+    if skip_check or check_proceed(len(sorted_priced_transfers)):
         transfer_req = build_transfer_payload(
             sorted_priced_transfers, current_gw, fetcher, chip_played
         )
         fetcher.post_transfers(transfer_req)
+    else:
+        print("Not applying transfers.  Can still choose starting 11 and captain.")
+        return False
     return True
 
 

--- a/airsenal/scripts/set_lineup.py
+++ b/airsenal/scripts/set_lineup.py
@@ -83,7 +83,9 @@ def make_squad_transfers(squad: Squad, priced_transfers: List[dict]) -> None:
         squad.add_player(t[1][0], price=t[1][1])
 
 
-def set_lineup(fpl_team_id: Optional[int] = None) -> None:
+def set_lineup(
+    fpl_team_id: Optional[int] = None, verbose: Optional[bool] = False
+) -> None:
     """
     Retrieve the latest lineup and apply the latest prediction to it.
 
@@ -91,11 +93,14 @@ def set_lineup(fpl_team_id: Optional[int] = None) -> None:
     """
     print(f"fpl_team_id is {fpl_team_id}")
     fetcher = FPLDataFetcher(fpl_team_id)
-    print(f"Got fetcher {fetcher.FPL_TEAM_ID}")
+    if verbose:
+        print(f"Got fetcher {fetcher.FPL_TEAM_ID}")
     picks = fetcher.get_lineup()
-    print(f"Got picks {picks}")
+    if verbose:
+        print(f"Got picks {picks}")
     squad = get_lineup_from_payload(picks)
-    print(f"got squad: {squad}")
+    if verbose:
+        print(f"got squad: {squad}")
 
     squad.optimize_lineup(NEXT_GAMEWEEK, get_latest_prediction_tag())
 


### PR DESCRIPTION
* Add a further "confirm" step in `airsenal_make_transfers` if more than two transfers are requested, warning the user that the script won't play the wildcard or free-hit chip for them.
* Add a line to README also warning the user about that.
* Put some print output of set_lineup behind a "verbose" flag.

Closes #550