### PR TITLE
give free wild card for gw following 2022 world cup

### DIFF
--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -475,6 +475,12 @@ def run_optimization(
     # in each gw
     chip_gw_dict = construct_chip_dict(gameweeks, chip_gameweeks)
 
+    # Specific fix (aka hack) for the 2022 World Cup, where everyone
+    # gets a free wildcard
+    if season == "2223" and gameweeks[0] == 17:
+        chip_gw_dict[gameweeks[0]]["chip_to_play"] = "wildcard"
+        num_free_transfers = 1
+
     # create a queue that we will add nodes to, and some processes to take
     # things off it
     squeue = CustomQueue()


### PR DESCRIPTION
Quick and hack-y fix to #555, where optimization hangs as a result of the number of strategies evaluated by the tree search not being equal to the number returned by `count_expected_outputs`, which in turn is a consequence of how we deal with the API telling us we have zero free transfers.

Fix is to set the "chip_to_play" to "wildcard" and "num_free_transfers" to 1, for this specific gameweek (22/23 season, gameweek 17).

Will revisit actual case of zero free transfers later - see discussion on #555 for more detail.