### PR TITLE
Avoid pygmo not found error if not installed (again)

### DIFF
--- a/airsenal/scripts/squad_builder.py
+++ b/airsenal/scripts/squad_builder.py
@@ -2,9 +2,7 @@
 
 import argparse
 import sys
-from typing import List, Optional
-
-from pygmo.core import sga
+from typing import List
 
 from airsenal.framework.optimization_squad import make_new_squad
 from airsenal.framework.optimization_utils import (
@@ -34,19 +32,21 @@ def fill_initial_squad(
     algorithm: str = "genetic",
     remove_zero: bool = True,
     sub_weights: dict = DEFAULT_SUB_WEIGHTS,
-    uda: Optional[sga] = None,
+    num_generations: int = 100,
     population_size: int = 100,
     num_iterations: int = 10,
     verbose: bool = True,
 ) -> None:
-    if algorithm == "genetic" and uda is None:
+    if algorithm == "genetic":
         try:
             import pygmo as pg
 
-            uda = pg.sga(gen=100)
+            uda = pg.sga(gen=num_generations)
         except ModuleNotFoundError:
             print("pygmo not available. Defaulting to algorithm=normal instead")
             algorithm = "normal"
+    else:
+        uda = None
 
     gw_start = gw_range[0]
     best_squad = make_new_squad(
@@ -197,17 +197,6 @@ def main():
         sub_weights = {"GK": 0, "Outfield": (0, 0, 0)}
     else:
         sub_weights = {"GK": 0.01, "Outfield": (0.4, 0.1, 0.02)}
-    if algorithm == "genetic":
-        try:
-            import pygmo as pg
-
-            uda = pg.sga(gen=num_generations)
-        except ModuleNotFoundError:
-            print("pygmo not available. Defaulting to algorithm=normal instead")
-            algorithm = "normal"
-            uda = None
-    else:
-        uda = None
 
     fill_initial_squad(
         tag=tag,
@@ -218,7 +207,7 @@ def main():
         algorithm=algorithm,
         remove_zero=remove_zero,
         sub_weights=sub_weights,
-        uda=uda,
+        num_generations=num_generations,
         population_size=population_size,
         num_iterations=num_iterations,
         verbose=verbose,

--- a/airsenal/scripts/squad_builder.py
+++ b/airsenal/scripts/squad_builder.py
@@ -45,6 +45,7 @@ def fill_initial_squad(
         except ModuleNotFoundError:
             print("pygmo not available. Defaulting to algorithm=normal instead")
             algorithm = "normal"
+            uda = None
     else:
         uda = None
 


### PR DESCRIPTION
Highlighted in #559, we can get `No module named 'pygmo'`. In https://github.com/alan-turing-institute/AIrsenal/issues/495#issuecomment-1212111173, @jack89roberts noted it wasn't possible to get that error anymore. But from adding in more type-hints in #544, I re-introduced this errror as I imported pygmo to make the appropriate type-hint.

This PR fixes this by:
- removing possibility to pass in `uda` argument which was an optional `pygmo.sga` type
- passing in new argument `num_generations` which defaults to 100
- if `algorithm = "genetic"`, it attempts to use `pygmo` with `num_generations` argument, else it defaults to using `algorithm = "normal"` and sets `uda=None`