### PR TITLE
add xg, xa, xgi, xgc data to player score

### DIFF
--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -286,6 +286,10 @@ class PlayerScore(Base):
     creativity = Column(Float, nullable=True)
     threat = Column(Float, nullable=True)
     ict_index = Column(Float, nullable=True)
+    expected_goals = Column(Float, nullable=True)
+    expected_assists = Column(Float, nullable=True)
+    expected_goal_involvements = Column(Float, nullable=True)
+    expected_goals_conceded = Column(Float, nullable=True)
 
     def __str__(self):
         return (


### PR DESCRIPTION
For #567.

Note that will need to start a new database by running `airsenal_setup_initial_db --clean` first.