### PR TITLE
Add information for teams for the 17-18 season

### DIFF
--- a/airsenal/data/fifa_team_ratings_1718.csv
+++ b/airsenal/data/fifa_team_ratings_1718.csv
@@ -19,3 +19,8 @@ Burnley,74,75,75,75
 Newcastle United,74,75,75,75
 Brighton & Hove Albion,74,74,73,74
 Huddersfield Town,73,73,72,73
+Norwich City,73,73,74,73
+Aston Villa,74,73,73,73
+Sunderland,81,76,73,76
+Hull City,76,74,75,75
+Middlesbrough,76,74,74,75

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -57,7 +57,8 @@ def get_ratings_dict(season, teams, dbsession):
         raise ValueError(
             f"Must have FIFA ratings and results for all teams. {len(ratings_dict)} "
             + f"teams with FIFA ratings but {len(teams)} teams with results."
-            + f"the effected teams are {set(ratings_dict.keys()).symmetric_difference(teams)}"
+            + f"the effected teams are "
+            + f"{set(ratings_dict.keys()).symmetric_difference(teams)}"
         )
     return ratings_dict
 

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -57,6 +57,7 @@ def get_ratings_dict(season, teams, dbsession):
         raise ValueError(
             f"Must have FIFA ratings and results for all teams. {len(ratings_dict)} "
             + f"teams with FIFA ratings but {len(teams)} teams with results."
+            + f"the effected teams are {set(ratings_dict.keys()).symmetric_difference(teams)}"
         )
     return ratings_dict
 

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -57,7 +57,7 @@ def get_ratings_dict(season, teams, dbsession):
         raise ValueError(
             f"Must have FIFA ratings and results for all teams. {len(ratings_dict)} "
             + f"teams with FIFA ratings but {len(teams)} teams with results."
-            + f"the effected teams are "
+            + "the effected teams are "
             + f"{set(ratings_dict.keys()).symmetric_difference(teams)}"
         )
     return ratings_dict

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -57,7 +57,7 @@ def get_ratings_dict(season, teams, dbsession):
         raise ValueError(
             f"Must have FIFA ratings and results for all teams. {len(ratings_dict)} "
             + f"teams with FIFA ratings but {len(teams)} teams with results."
-            + "the effected teams are "
+            + " The teams involved are "
             + f"{set(ratings_dict.keys()).symmetric_difference(teams)}"
         )
     return ratings_dict


### PR DESCRIPTION
Closes issue #580 

Data collected from https://www.fifaindex.com/teams/ for the 10th August (2017) which should be just before the start of the 17/18 season