### PR TITLE
Bugfix 630/invalid team

### DIFF
--- a/airsenal/framework/optimization_transfers.py
+++ b/airsenal/framework/optimization_transfers.py
@@ -448,27 +448,13 @@ def make_best_transfers(
         players_out = [p for p in _out if p not in _in]  # remove duplicates
         transfer_dict["in"] += players_in
         transfer_dict["out"] += players_out
-    # not a wildcard or free hit - modify our existing squad
     else:
-        # see if we need to do any compulsory transfers e.g. if we have
+        # not a wildcard or free hit - modify our existing squad.
+        # First see if we need to do any compulsory transfers e.g. if we have
         # >3 players from the same team, after the (real) transfer window
         candidate_players_to_remove, num_players_to_remove = find_compulsory_transfers(
             squad
         )
-        if num_players_to_remove > 2:
-            squad, players_out, players_in = make_random_transfers(
-                squad,
-                tag,
-                num_players_to_remove,
-                gameweeks,
-                root_gw,
-                season,
-                triple_captain_gw=triple_captain_gw,
-                bench_boost_gw=bench_boost_gw,
-                candidate_players_to_remove=candidate_players_to_remove,
-            )
-            transfer_dict["in"] += players_in
-            transfer_dict["out"] += players_out
 
         if num_transfers == 0:
             # 0 or 'T0' or 'B0' (i.e. zero transfers, possibly with chip)

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -180,6 +180,8 @@ def get_squad_from_transactions(gameweek, season=CURRENT_SEASON, fpl_team_id=Non
                 check_budget=False,
                 check_team=False,
             )
+    # make sure all the players' teams are up-to-date
+    s.update(gameweek)
     return s
 
 

--- a/airsenal/framework/player.py
+++ b/airsenal/framework/player.py
@@ -68,5 +68,5 @@ class CandidatePlayer(object):
         update team info for player (in case they were transferred since
         being added to a squad)
         """
-        pdata = get_player(self.player_id)
+        pdata = get_player(self.player_id, dbsession=self.dbsession)
         self.team = pdata.team(self.season, gameweek)

--- a/airsenal/framework/player.py
+++ b/airsenal/framework/player.py
@@ -62,3 +62,11 @@ class CandidatePlayer(object):
             print(f"No prediction available for {self.name} week {gameweek}")
             return 0.0
         return self.predicted_points[tag][gameweek]
+
+    def update_team(self, gameweek):
+        """
+        update team info for player (in case they were transferred since
+        being added to a squad)
+        """
+        pdata = get_player(self.player_id)
+        self.team = pdata.team(self.season, gameweek)

--- a/airsenal/framework/squad.py
+++ b/airsenal/framework/squad.py
@@ -481,3 +481,32 @@ class Squad(object):
                         subs.remove(p_in)
                         break
         return total_points
+
+    def update(self, gameweek):
+        """
+        If real life players changed teams, update the 'team'
+        of the CandidatePlayer in the squad
+        """
+        for p in self.players:
+            p.update_team(gameweek)
+
+    def players_per_team(self):
+        """
+        Return a dict of player_ids keyed by team.
+        Useful for determining if we have a legal squad (e.g. after the transfer window,
+        if players changed teams, we might have >3 players from one team).
+
+        Returns:
+            team_player_dict: dict{str,CandidatePlayer} , is_legal: bool
+        """
+        team_player_dict = {}
+        for p in self.players:
+            if p.team not in team_player_dict.keys():
+                team_player_dict[p.team] = []
+            team_player_dict[p.team].append(p)
+        is_legal = True
+        for v in team_player_dict.values():
+            if len(v) > 3:
+                is_legal = False
+                break
+        return team_player_dict, is_legal

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -11,7 +11,7 @@ output for each strategy tried is going to be a dict
 "players_bought" : {<gw>: [], ...}
 }
 This is done via a recursive tree search, where nodes on the tree do an optimization
-for a given number of transfers, then adds some children to the multiprocessing queue
+for a given number of transfers, then add some children to the multiprocessing queue
 representing 0, 1, 2 transfers for the next gameweek.
 
 """
@@ -660,7 +660,7 @@ def construct_chip_dict(gameweeks: List[int], chip_gameweeks: dict) -> dict:
     where <chip_name> is e.g. 'wildcard', and <chip_gw> is -1 if chip
     is not to be played, 0 if it is to be considered any week, or gw
     if it is definitely to be played that gw, return a dict
-    { <gw>: {"chip_to_play": [<chip_name>],
+    { <gw>: {"chip_to_play": <chip_name>,
              "chips_allowed": [<chip_name>,...]},...}
     """
     chip_dict = {}


### PR DESCRIPTION
Issue #630 illustrates the problem that when a real-life player changes team, it is possible for an FPL squad to end up with >3 players from the same team, violating the squad constraints.
The desired behaviour is that the AIrsenal optimization should remove player(s) at the first opportunity, to ensure that the squad is valid.
However:
* If the "starting squad" for a round of optimization is constructed from the Transaction table in the db, rather than being obtained from the API, the "team" attribute of each PlayerCandidate will be the team at the time that player was transferred in.
* Even if the starting squad for optimization has the correct team (i.e. is invalid, with >3 players from the same team), it doesn't necessarily suggest transferring out player(s) to make it a valid team.

This PR does the following:
* Adds `update_team` method to CandidatePlayer, which retrieves the correct team from the PlayerAttribute for the desired gameweek.
* Adds `update` method to Squad, which calls `update_team` for all players in the squad.
* Calls `squad.update(gameweek)` at the end of `get_squad_from_transactions`.  
At this point, the starting squad has the correct teams for all players, but more changes needed to enforce transfers that will ensure a valid team:
* Add `players_per_team` method to Squad that can identify if a squad has too many players from one team.
* Add `find_compulsory_transfers` function in `optimization_transfers.py` that uses that information to make a list of players from those teams where we have >3 players, and how many players we need to remove in order to have a valid team.
* Small modifications to `make_optimum_single_transfer`, `make_optimum_double_transfer`, `make_random_transfers` so that they can optionally take a list of players from which to select who to remove (rather than looping over all players in the squad).
* Re-jig the logic and add code in `make_best_transfers` so that if we are not doing wildcard or free_hit, we first check whether we need to make compulsory transfers, make them if necessary using the functions mentioned above with the list of candidate_players_to_remove, and then subtract the number of compulsory transfers from num_transfers before proceeding with the normal logic.

The above seems to work.... BUT... we are not altering the "strategies" or the number of expected outputs.   I think this is fine, except that for strategies with zero transfers in the first gameweek, we will actually be doing a transfer, but it won't be taken into account in the points hit calculation.    To me, I think this is a fairly minor and specific problem, and fixing it would add a lot more complication, so it is probably a fair price to pay, but happy to hear other opinions!