### PR TITLE
include mins from whole season in estimate_minutes_from_prev_season

### DIFF
--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -1337,7 +1337,6 @@ def estimate_minutes_from_prev_season(
         .filter_by(player_team=current_team)
         .join(Fixture, PlayerScore.fixture)
         .order_by(desc(Fixture.gameweek))
-        .limit(n_games_to_use)
         .all()
     )
 
@@ -1345,7 +1344,14 @@ def estimate_minutes_from_prev_season(
         # no FPL history / didn't play for current team last season
         return [0]
 
-    average_mins = calc_average_minutes(player_scores)
+    # Use average of last n games and all games from last season. Attempts to balance
+    # whether player was first choice at the end of the season vs. whether they were
+    # only not playing at the end of the season due to rotation/injury. First-choice
+    # players with long-term injuries early in the season will be underestimated.
+    average_mins_last_n = calc_average_minutes(player_scores[-n_games_to_use:])
+    average_mins_season = calc_average_minutes(player_scores)
+    average_mins = (average_mins_last_n + average_mins_season) / 2
+
     return [average_mins]
 
 


### PR DESCRIPTION
Tweaks start of season minutes estimation to use average of minutes played in whole of last season (what AIrsenal used in first few seasons) and minutes played in last 10 games of the previous season (what AIrsenal used in last couple of seasons). Aiming to be a better balance between players that were injured at the end of the season and players that genuinely lost their place at the end of the season.