### PR TITLE
Assistant Manager

### DIFF
--- a/airsenal/framework/FPL_scoring_rules.py
+++ b/airsenal/framework/FPL_scoring_rules.py
@@ -1,7 +1,10 @@
 """
-How many points does FPL assign for goals, assists, clean sheets, appearances
+How many points does FPL assign for goals, assists, clean sheets, appearances etc.
 """
 
+###############
+### PLAYERS ###
+###############
 points_for_goal = {"GK": 10, "DEF": 6, "MID": 5, "FWD": 4}
 
 points_for_cs = {"GK": 4, "DEF": 4, "MID": 1, "FWD": 0}
@@ -28,3 +31,15 @@ def get_appearance_points(minutes):
         if minutes >= 60:
             app_points += 1
     return app_points
+
+
+################
+### MANAGERS ###
+################
+
+points_for_manager_win = 6
+points_for_manager_table_bonus_win = 10
+points_for_manager_draw = 3
+points_for_manager_table_bonus_draw = 5
+points_for_manager_goal = 1
+points_for_manager_clean_sheet = 2

--- a/airsenal/framework/FPL_scoring_rules.py
+++ b/airsenal/framework/FPL_scoring_rules.py
@@ -2,9 +2,7 @@
 How many points does FPL assign for goals, assists, clean sheets, appearances etc.
 """
 
-###############
-### PLAYERS ###
-###############
+# PLAYERS
 points_for_goal = {"GK": 10, "DEF": 6, "MID": 5, "FWD": 4}
 
 points_for_cs = {"GK": 4, "DEF": 4, "MID": 1, "FWD": 0}
@@ -33,10 +31,7 @@ def get_appearance_points(minutes):
     return app_points
 
 
-################
-### MANAGERS ###
-################
-
+# MANAGERS
 points_for_manager_win = 6
 points_for_manager_table_bonus_win = 10
 points_for_manager_draw = 3

--- a/airsenal/framework/player.py
+++ b/airsenal/framework/player.py
@@ -11,7 +11,7 @@ from airsenal.framework.utils import (
 )
 
 
-class CandidatePlayer(object):
+class CandidatePlayer:
     """
     player class
     """

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -619,7 +619,7 @@ def list_players(
     gameweek: int = NEXT_GAMEWEEK,
     dbsession: Optional[Session] = None,
     verbose: bool = False,
-) -> List[int]:
+) -> List[Player]:
     """
     Print list of players and return a list of player_ids.
     """
@@ -686,7 +686,7 @@ def list_players(
     if position != "all":
         q = q.filter_by(position=position)
     else:
-        # exclude managers
+        # exclude managers by default
         q = q.filter(PlayerAttributes.position != "MNG")
     if len(gameweeks) > 1:
         #  Sort query results by order of gameweeks - i.e. make sure the input
@@ -1139,6 +1139,19 @@ def get_top_predicted_points(
             season=season,
             dbsession=dbsession,
         )
+        if position == "all":
+            # manager points not usually included by default in other functions, but
+            # include it here
+            pts.append(
+                get_predicted_points(
+                    gameweek,
+                    tag,
+                    position="MNG",
+                    team=team,
+                    season=season,
+                    dbsession=dbsession,
+                )
+            )
         if max_price is not None:
             pts = [p for p in pts if p[0].price(season, first_gw) <= max_price]
 
@@ -1181,7 +1194,7 @@ def get_top_predicted_points(
             else:
                 print("Warning: Discord webhook url is malformed!\n", discord_webhook)
     else:
-        for position in ["GK", "DEF", "MID", "FWD"]:
+        for position in ["GK", "DEF", "MID", "FWD", "MNG"]:
             pts = get_predicted_points(
                 gameweek,
                 tag,

--- a/airsenal/scripts/activate_assistant_manager.py
+++ b/airsenal/scripts/activate_assistant_manager.py
@@ -1,0 +1,75 @@
+from typing import List
+
+from tqdm import tqdm
+
+from airsenal.framework.optimization_transfers import activate_assistant_manager
+from airsenal.framework.optimization_utils import get_num_increments, get_starting_squad
+from airsenal.framework.schema import session
+from airsenal.framework.squad import Squad
+from airsenal.framework.utils import (
+    get_latest_prediction_tag,
+    get_player,
+)
+
+
+def main(
+    squad: Squad,
+    gw_range: List[int],
+    season: str,
+    tag: str,
+    num_iter=100,
+    dbsession=session,
+) -> None:
+    best_squad = None
+    best_transfers = {}
+    best_pts = 0
+    for nt in [3]:  # [0, 1, 2, 3]:
+        num_increments_for_updater = 20 * get_num_increments(nt, num_iter)
+        pid = f"A{nt}"
+        progress_bar = tqdm(total=num_increments_for_updater, desc=pid)
+        increment = 1
+
+        def updater(increment=1, index=None):
+            progress_bar.update(increment)
+
+        try:
+            new_squad, new_transfers, new_pts = activate_assistant_manager(
+                nt,
+                squad,
+                tag,
+                gw_range,
+                gw_range[0],
+                season,
+                num_iter=num_iter,
+                update_func_and_args=(updater, increment, pid),
+                verbose=False,
+            )
+            print("Points", new_pts)
+            print(new_squad)
+            print_transfers(new_transfers)
+            if new_pts > best_pts:
+                best_squad = new_squad
+                best_transfers = new_transfers
+                best_pts = new_pts
+        except Exception as e:
+            print(f"Failed with {nt}: {e}")
+
+    print("==========================")
+    print("Best squad:")
+    print("Points:", best_pts)
+    print(best_squad)
+    print_transfers(best_transfers)
+
+
+def print_transfers(transfers):
+    print("Transfers:")
+    print(f"- IN: {[get_player(player_id).name for player_id in transfers['in']]}")
+    print(f"- OUT: {[get_player(player_id).name for player_id in transfers['out']]}")
+
+
+if __name__ == "__main__":
+    squad = get_starting_squad()
+    gw_range = [36, 37, 38]
+    season = "2425"
+    tag = get_latest_prediction_tag()
+    main(squad=squad, gw_range=gw_range, season=season, tag=tag)

--- a/airsenal/scripts/dump_db_contents.py
+++ b/airsenal/scripts/dump_db_contents.py
@@ -5,172 +5,37 @@ Script to dump the database contents.
 import csv
 import os
 
-from airsenal.framework.schema import (
-    FifaTeamRating,
-    Fixture,
-    Player,
-    PlayerAttributes,
-    PlayerScore,
-    Result,
-    Team,
-    Transaction,
-)
+from sqlalchemy import inspect
+
+from airsenal.framework.schema import Base
 from airsenal.framework.utils import session
 
 
 def main():
-    # Dump Player database
-    player_fieldnames = ["player_id", "name"]
-    save_table_fields(
-        "../data/players.csv",
-        player_fieldnames,
-        Player,
-        " ==== dumped Player database === ",
-    )
+    dump_path = os.path.join(os.path.dirname(__file__), "../data/db_dump")
+    os.makedirs(dump_path, exist_ok=True)
 
-    # Dump PlayerAttributes database
-    player_attributes_fieldnames = [
-        "id",
-        "player_id",
-        "season",
-        "gameweek",
-        "price",
-        "team",
-        "position",
-        "transfers_balance",
-        "selected",
-        "transfers_in",
-        "transfers_out",
-    ]
-    save_table_fields(
-        "../data/player_attributes.csv",
-        player_attributes_fieldnames,
-        PlayerAttributes,
-        " ==== dumped PlayerAttributes database === ",
-    )
-
-    # Dump Fixture database
-    fixture_fieldnames = [
-        "fixture_id",
-        "date",
-        "gameweek",
-        "home_team",
-        "away_team",
-        "season",
-        "tag",
-        "player_id",
-    ]
-    save_table_fields(
-        "../data/fixtures.csv",
-        fixture_fieldnames,
-        Fixture,
-        " ==== dumped Fixture database === ",
-    )
-
-    # Dump Result database
-    result_fieldnames = [
-        "result_id",
-        "fixture_id",
-        "home_score",
-        "away_score",
-        "player_id",
-    ]
-    save_table_fields(
-        "../data/results.csv",
-        result_fieldnames,
-        Result,
-        " ==== dumped Result database === ",
-    )
-
-    # Dump Team database
-    team_fieldnames = ["id", "name", "full_name", "season", "team_id"]
-    save_table_fields(
-        "../data/teams.csv",
-        team_fieldnames,
-        Team,
-        " ==== dumped Team database === ",
-    )
-
-    # Dump FifaTeamRating database
-    # Add season to the fieldnames once the table creation is updated
-    fifa_team_rating_fieldnames = ["team", "att", "defn", "mid", "ovr"]
-    save_table_fields(
-        "../data/fifa_team_ratings.csv",
-        fifa_team_rating_fieldnames,
-        FifaTeamRating,
-        " ==== dumped FifaTeamRating database === ",
-    )
-
-    # Dump Transaction database
-    transaction_fieldnames = [
-        "id",
-        "player_id",
-        "gameweek",
-        "bought_or_sold",
-        "season",
-        "tag",
-        "price",
-    ]
-    save_table_fields(
-        "../data/transactions.csv",
-        transaction_fieldnames,
-        Transaction,
-        " ==== dumped Transaction database === ",
-    )
-
-    # Dump PlayerScore database
-    player_score_fieldnames = [
-        "id",
-        "player_team",
-        "opponent",
-        "points",
-        "goals",
-        "assists",
-        "bonus",
-        "conceded",
-        "minutes",
-        "player_id",
-        "result_id",
-        "fixture_id",
-        "clean_sheets",
-        "own_goals",
-        "penalties_saved",
-        "penalties_missed",
-        "yellow_cards",
-        "red_cards",
-        "saves",
-        "bps",
-        "influence",
-        "creativity",
-        "threat",
-        "ict_index",
-        "value",
-        "transfers_balance",
-        "selected",
-        "transfers_in",
-        "transfers_out",
-    ]
-    save_table_fields(
-        "../data/player_scores.csv",
-        player_score_fieldnames,
-        PlayerScore,
-        " ==== dumped PlayerScore database === ",
-    )
+    tables = dict(Base.metadata.tables)
+    for name, dbclass in tables.items():
+        print(dbclass, type(dbclass))
+        print("dumping table: ", name)
+        save_table_fields(dump_path, dbclass, name)
 
 
-def save_table_fields(path, fields, dbclass, msg):
-    result = os.path.join(os.path.dirname(__file__), path)
+def save_table_fields(path, dbclass, tablename):
+    result = os.path.join(path, f"{tablename}.csv")
     with open(result, "w") as csvfile:
-        write_rows_to_csv(csvfile, fields, dbclass)
-    print(msg)
+        write_rows_to_csv(csvfile, dbclass)
 
     return result
 
 
-def write_rows_to_csv(csvfile, fieldnames, dbclass):
+def write_rows_to_csv(csvfile, dbclass):
+    fieldnames = [col.name for col in inspect(dbclass).columns]
     writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
     writer.writeheader()
     for player in session.query(dbclass).all():
+        print(player, dbclass)
         player = vars(player)
         row = {
             field: player[field]

--- a/airsenal/tests/test_score_predictions.py
+++ b/airsenal/tests/test_score_predictions.py
@@ -295,7 +295,7 @@ def test_get_result_dict():
 
 def test_get_ratings_dict():
     with past_data_session_scope() as ts:
-        rd = lt_dict("1819", 10, ts)
+        rd = get_result_dict("1819", 10, ts)
         teams = set(rd["home_team"]) | set(rd["away_team"])
         d = get_ratings_dict("1819", teams, ts)
         assert isinstance(d, dict)

--- a/airsenal/tests/test_score_predictions.py
+++ b/airsenal/tests/test_score_predictions.py
@@ -295,7 +295,7 @@ def test_get_result_dict():
 
 def test_get_ratings_dict():
     with past_data_session_scope() as ts:
-        rd = get_result_dict("1819", 10, ts)
+        rd = lt_dict("1819", 10, ts)
         teams = set(rd["home_team"]) | set(rd["away_team"])
         d = get_ratings_dict("1819", teams, ts)
         assert isinstance(d, dict)

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: airsenalenv
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.12
   - pip


### PR DESCRIPTION
**Done:**
- Managers added to database as players (including manager scores, attributes but most of them will be zero/blank as they don't apply to managers)
- Predict manager points in a fixture using the team model + assistant manager scoring rules, and add them to the database
- `airsenal_run_prediction` now computes manager prediction points and adds them to the database

**Todo:**
- Predict league table for future gameweeks based on match result probabilities. Currently assume positions at the start of the first gameweek are fixed (league position impacts whether table bonus is available or not) - probably spin out into another issue rather than here.
- Optimisation
  - Squads can optionally have managers. All the same rules re budget and no. of players per team apply.
  - Assistant manager is active for 3 gameweeks once used.
  - Additional position to consider for transfers when assistant manager is active.