### PR TITLE
Set default team model time weighting to 1.5

### DIFF
--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -19,6 +19,11 @@ from airsenal.framework.utils import (
 
 np.random.seed(42)
 
+# Default time weighting for team model, calculated using best on average across 20/21
+# to 24/25 season, assuming 3 seasons of history before the current season in the DB and
+# predicting 5 weeks ahead.
+DEFAULT_EPSILON = 1.5
+
 
 def get_result_dict(
     season: str, gameweek: int, dbsession: Session
@@ -138,9 +143,10 @@ def create_and_fit_team_model(
         print(f"Fitting {type(model)} model with epsilon = {fit_args['epsilon']}")
     else:
         print(
-            f"Fitting {type(model)} model but no epsilon passed, "
-            "so using the default epsilon = 0"
+            f"Fitting {type(model)} model but no epsilon passed, so using the default"
+            f"epsilon = {DEFAULT_EPSILON}"
         )
+        fit_args["epsilon"] = DEFAULT_EPSILON
 
     return model.fit(training_data=training_data, **fit_args)
 

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -143,7 +143,7 @@ def create_and_fit_team_model(
         print(f"Fitting {type(model)} model with epsilon = {fit_args['epsilon']}")
     else:
         print(
-            f"Fitting {type(model)} model but no epsilon passed, so using the default"
+            f"Fitting {type(model)} model but no epsilon passed, so using the default "
             f"epsilon = {DEFAULT_EPSILON}"
         )
         fit_args["epsilon"] = DEFAULT_EPSILON

--- a/airsenal/scripts/airsenal_run_pipeline.py
+++ b/airsenal/scripts/airsenal_run_pipeline.py
@@ -8,6 +8,7 @@ from bpl import ExtendedDixonColesMatchPredictor, NeutralDixonColesMatchPredicto
 from sqlalchemy.orm.session import Session
 from tqdm import TqdmWarning
 
+from airsenal.framework.bpl_interface import DEFAULT_EPSILON
 from airsenal.framework.multiprocessing_utils import set_multiprocessing_start_method
 from airsenal.framework.random_team_model import RandomMatchPredictor
 from airsenal.framework.schema import session_scope
@@ -106,7 +107,7 @@ from airsenal.scripts.update_db import update_db
     "--epsilon",
     help="how much to downweight games by in exponential time weighting",
     type=float,
-    default=0.0,
+    default=DEFAULT_EPSILON,
 )
 @click.option(
     "--max_transfers",
@@ -314,7 +315,7 @@ def run_prediction(
     Run prediction
     """
     if team_model_args is None:
-        team_model_args = {"epsilon": 0.0}
+        team_model_args = {"epsilon": DEFAULT_EPSILON}
     season = CURRENT_SEASON
     tag = make_predictedscore_table(
         gw_range=gw_range,

--- a/airsenal/scripts/fill_playerscore_table.py
+++ b/airsenal/scripts/fill_playerscore_table.py
@@ -105,8 +105,8 @@ def fill_playerscores_from_json(
             # extended features
             # get features excluding the core ones already populated above
             for feat in extended_feats:
-                # with contextlib.suppress(KeyError):
-                ps.__setattr__(feat, fixture_data[feat])
+                with contextlib.suppress(KeyError):
+                    ps.__setattr__(feat, fixture_data[feat])
 
             dbsession.add(ps)
     dbsession.commit()

--- a/airsenal/scripts/fill_predictedscore_table.py
+++ b/airsenal/scripts/fill_predictedscore_table.py
@@ -15,6 +15,7 @@ from pandas import Series
 from sqlalchemy.orm.session import Session
 
 from airsenal.framework.bpl_interface import (
+    DEFAULT_EPSILON,
     get_fitted_team_model,
     get_goal_probabilities_for_fixtures,
 )
@@ -98,7 +99,7 @@ def calc_all_predicted_points(
     Do the full prediction for players.
     """
     if team_model_args is None:
-        team_model_args = {"epsilon": 0.0}
+        team_model_args = {"epsilon": DEFAULT_EPSILON}
     model_team = get_fitted_team_model(
         season=season,
         gameweek=min(gw_range),
@@ -199,7 +200,7 @@ def make_predictedscore_table(
     dbsession: Session = session,
 ) -> str:
     if team_model_args is None:
-        team_model_args = {"epsilon": 0.0}
+        team_model_args = {"epsilon": DEFAULT_EPSILON}
     tag = tag_prefix or ""
     tag += str(uuid4())
     if not gw_range:

--- a/airsenal/scripts/replay_season.py
+++ b/airsenal/scripts/replay_season.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from sqlalchemy.orm.session import Session
 from tqdm import TqdmWarning, tqdm
 
+from airsenal.framework.bpl_interface import DEFAULT_EPSILON
 from airsenal.framework.multiprocessing_utils import set_multiprocessing_start_method
 from airsenal.framework.schema import Transaction, session_scope
 from airsenal.framework.utils import (
@@ -66,7 +67,7 @@ def replay_season(
     max_opt_transfers: int = 2,
 ) -> None:
     if team_model_args is None:
-        team_model_args = {"epsilon": 0.0}
+        team_model_args = {"epsilon": DEFAULT_EPSILON}
     start = datetime.now()
     if gameweek_end is None:
         gameweek_end = get_max_gameweek(season)

--- a/airsenal/scripts/set_env.py
+++ b/airsenal/scripts/set_env.py
@@ -17,14 +17,14 @@ def redact_db_password(conn_str: str) -> str:
         # Format: postgresql://user:password@host/dbname
         # Find the user:password part
         prefix = "postgresql://"
-        rest = conn_str[len(prefix):]
+        rest = conn_str[len(prefix) :]
         if "@" in rest:
             creds, host_db = rest.split("@", 1)
             if ":" in creds:
                 user, _ = creds.split(":", 1)
-                redacted = f"{prefix}{user}:***@{host_db}"
-                return redacted
+                return f"{prefix}{user}:***@{host_db}"
     return conn_str
+
 
 def print_env():
     print(f"AIRSENAL_VERSION: {__version__}")

--- a/airsenal/scripts/tune_team_time_weighting.py
+++ b/airsenal/scripts/tune_team_time_weighting.py
@@ -1,0 +1,275 @@
+"""
+Tune the time-weighting (epsilon) hyperparameter for the team model by
+maximising the summed log-probability of actual scorelines on a rolling
+"train up to GW t, evaluate on GW t+1..t+H" basis.
+
+Steps per epsilon:
+ 1) For each gameweek in the season (up to max_gw - horizon), fit the team model
+    using only results strictly before that gameweek (as if we were at GW t).
+ 2) For the next `horizon` gameweeks, compute the model probability of the
+    actual (home_goals, away_goals) observed for each fixture.
+ 3) Accumulate the sum of log probabilities across all evaluated fixtures.
+ 4) Report the epsilon with the highest total log-probability.
+"""
+
+import argparse
+import csv
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from bpl import ExtendedDixonColesMatchPredictor
+from sqlalchemy.orm.session import Session
+from tqdm import tqdm
+
+from airsenal.framework.bpl_interface import get_fitted_team_model
+from airsenal.framework.schema import Fixture, session_scope
+from airsenal.framework.utils import (
+    get_fixtures_for_gameweek,
+    get_max_gameweek,
+)
+
+
+@dataclass
+class EpsilonResult:
+    epsilon: float
+    total_log_prob: float
+    num_fixtures: int
+
+
+def _safe_log(p: float) -> float:
+    # guard against zero probabilities
+    return float(np.log(max(p, 1e-12)))
+
+
+def _score_fixtures(
+    fixtures: Iterable[Fixture], model: ExtendedDixonColesMatchPredictor
+) -> tuple[float, int]:
+    """Sum log-probability of actual scorelines for a collection of fixtures.
+
+    Returns (sum_log_prob, n_fixtures_scored)
+    """
+    sum_logp = 0.0
+    n = 0
+    for f in fixtures:
+        if f.result is None:
+            continue
+        hg = int(f.result.home_score)
+        ag = int(f.result.away_score)
+
+        # predict_score_proba returns joint probability of exact scoreline
+        proba = model.predict_score_proba(
+            np.array([f.home_team]),
+            np.array([f.away_team]),
+            np.array([hg]),
+            np.array([ag]),
+        )
+        # coerce to array and extract scalar
+        arr = np.asarray(proba).ravel()
+        prob = float(arr[0])
+        sum_logp += _safe_log(prob)
+        n += 1
+    return sum_logp, n
+
+
+def evaluate_epsilon(
+    epsilon: float,
+    seasons: list[str],
+    horizon: int,
+    dbsession: Session,
+    first_gw: int | None = None,
+    last_gw: int | None = None,
+) -> EpsilonResult:
+    """Evaluate a single epsilon value across the specified gameweek window."""
+
+    total_logp = 0.0
+    total_n = 0
+
+    for season in tqdm(seasons, desc="Season"):
+        max_gw = get_max_gameweek(season=season, dbsession=dbsession)
+        start_gw = first_gw or 1
+        # ensure we leave room for horizon weeks ahead
+        end_gw = last_gw if last_gw is not None else max_gw - horizon
+        end_gw = min(end_gw, max_gw - horizon)
+        if end_gw < start_gw:
+            msg = (
+                "Invalid GW window: "
+                f"start={start_gw}, end={end_gw}, max_gw={max_gw}, horizon={horizon}"
+            )
+            raise ValueError(msg)
+
+        for gw in tqdm(range(start_gw, end_gw + 1), desc="GW"):
+            print(f"\nFitting model for season {season} GW {gw}")
+            # Fit the model using data strictly before (season, gw+horizon start)
+            if not get_fixtures_for_gameweek(gw, season=season, dbsession=dbsession):
+                print(f"No fixtures found for season {season} GW {gw}, skipping")
+                continue
+            fitted = get_fitted_team_model(
+                season=season,
+                gameweek=gw,
+                dbsession=dbsession,
+                model=ExtendedDixonColesMatchPredictor(),
+                epsilon=epsilon,
+            )
+
+            # Evaluate on the next `horizon` gameweeks
+            eval_gws = list(range(gw + 1, gw + 1 + horizon))
+            fixtures = get_fixtures_for_gameweek(
+                eval_gws, season=season, dbsession=dbsession
+            )
+            logp, n = _score_fixtures(fixtures, fitted)  # type: ignore[arg-type]
+            total_logp += logp
+            total_n += n
+            print(f"\nGW {gw}: logp={logp:.3f}, n={n}")
+            print("------")
+
+    return EpsilonResult(
+        epsilon=epsilon, total_log_prob=total_logp, num_fixtures=total_n
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Tune epsilon for the team model")
+    parser.add_argument(
+        "--seasons",
+        nargs="+",
+        type=str,
+        help="Seasons to evaluate on, e.g. '2425'",
+    )
+    parser.add_argument(
+        "--horizon",
+        type=int,
+        default=3,
+        help="Number of future gameweeks to score for each fit (default: 3)",
+    )
+    parser.add_argument(
+        "--epsilons",
+        type=float,
+        nargs="*",
+        help="Explicit list of epsilon values to try (overrides start/stop/num)",
+    )
+    parser.add_argument(
+        "--epsilon-start",
+        type=float,
+        default=0.0,
+        help=(
+            "Start of epsilon range (inclusive) if --epsilons not given (default: 0.0)"
+        ),
+    )
+    parser.add_argument(
+        "--epsilon-stop",
+        type=float,
+        default=0.1,
+        help="End of epsilon range (inclusive) if --epsilons not given (default: 0.1)",
+    )
+    parser.add_argument(
+        "--epsilon-num",
+        type=int,
+        default=11,
+        help=(
+            "Number of grid points between start and stop if --epsilons "
+            "not given (default: 11)"
+        ),
+    )
+    parser.add_argument(
+        "--first-gw",
+        type=int,
+        default=None,
+        help="First gameweek to include for fitting (default: 1)",
+    )
+    parser.add_argument(
+        "--last-gw",
+        type=int,
+        default=None,
+        help=(
+            "Last gameweek to use as the 'fit as of' point (default: max_gw - horizon)"
+        ),
+    )
+    parser.add_argument(
+        "--out-csv",
+        type=str,
+        default=None,
+        help=(
+            "Optional path to save a CSV with one row per epsilon containing "
+            "epsilon,total_log_prob,num_fixtures,avg_log_prob. If not provided, "
+            "a file named tune_epsilon_results_<season>_h<horizon>.csv will be created "
+            "in the current directory."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    eps_grid = (
+        args.epsilons
+        if args.epsilons and len(args.epsilons) > 0
+        else list(np.linspace(args.epsilon_start, args.epsilon_stop, args.epsilon_num))
+    )
+
+    # Save results
+    out_path = (
+        Path(args.out_csv)
+        if args.out_csv is not None
+        else Path(f"tune_epsilon_results_{'_'.join(args.seasons)}_h{args.horizon}.csv")
+    )
+    with out_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["epsilon", "total_log_prob", "num_fixtures", "avg_log_prob"])
+
+    results: list[EpsilonResult] = []
+
+    with session_scope() as db:
+        db.expire_on_commit = False
+        for eps in tqdm(eps_grid, desc="Epsilon"):
+            res = evaluate_epsilon(
+                epsilon=eps,
+                seasons=args.seasons,
+                horizon=args.horizon,
+                dbsession=db,
+                first_gw=args.first_gw,
+                last_gw=args.last_gw,
+            )
+            print("\n========================================\n")
+            print(
+                "epsilon="
+                f"{res.epsilon:.5f}  total_log_prob={res.total_log_prob:.3f}  "
+                f"fixtures={res.num_fixtures}"
+            )
+            avg = (
+                res.total_log_prob / res.num_fixtures
+                if res.num_fixtures
+                else float("nan")
+            )
+            with out_path.open("a", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(
+                    [
+                        f"{res.epsilon:.6f}",
+                        f"{res.total_log_prob:.6f}",
+                        res.num_fixtures,
+                        f"{avg:.6f}",
+                    ]
+                )
+
+            print("\n========================================")
+            results.append(res)
+
+    if not results:
+        msg = "No results computed - check DB contents and arguments."
+        raise RuntimeError(msg)
+
+    best = max(results, key=lambda r: r.total_log_prob)
+    print()
+    print("=" * 60)
+    print(
+        "Best epsilon = "
+        f"{best.epsilon:.5f} with total log-probability "
+        f"{best.total_log_prob:.3f}"
+    )
+    print("=" * 60)
+
+    print(f"Saved results to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/airsenal/tests/test_score_predictions.py
+++ b/airsenal/tests/test_score_predictions.py
@@ -9,6 +9,7 @@ from bpl import ExtendedDixonColesMatchPredictor, NeutralDixonColesMatchPredicto
 
 from airsenal.conftest import past_data_session_scope
 from airsenal.framework.bpl_interface import (
+    DEFAULT_EPSILON,
     fixture_probabilities,
     get_fitted_team_model,
     get_ratings_dict,
@@ -308,11 +309,11 @@ def test_get_fitted_team_model():
         extended = ExtendedDixonColesMatchPredictor()
         model_team = get_fitted_team_model("1819", 10, ts, model=extended)
         assert isinstance(model_team, ExtendedDixonColesMatchPredictor)
-    # extended model with epsilon = 0.0 by default
+    # extended model with default epsilon
     with past_data_session_scope() as ts:
         model_team = get_fitted_team_model("1819", 10, ts)
         assert isinstance(model_team, ExtendedDixonColesMatchPredictor)
-        assert model_team.epsilon is None
+        assert model_team.epsilon == DEFAULT_EPSILON
     # extended model with epsilon = 0.5
     with past_data_session_scope() as ts:
         extended = ExtendedDixonColesMatchPredictor()
@@ -330,7 +331,7 @@ def test_get_fitted_team_model():
         neutral = NeutralDixonColesMatchPredictor()
         model_team = get_fitted_team_model("1819", 10, ts, model=neutral)
         assert isinstance(model_team, NeutralDixonColesMatchPredictor)
-        assert model_team.epsilon is None
+        assert model_team.epsilon == DEFAULT_EPSILON
 
 
 def test_fixture_probabilities():

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "airsenal"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Based on predicting 5 game weeks ahead, with 3 seasons of previous data in the database, epsilon = 1.5 (the team model time weighting) seems to be the best compromise across the last 5 seasons. It makes very little difference overall though (0.3% improvement in the predicted probability of the actual scoreline on average, but sometimes worse and sometimes better). It means about 80% of the total weighting will be given to matches within the last year.

<img width="581" height="446" alt="image" src="https://github.com/user-attachments/assets/91be07f7-12fe-4c13-9879-c63b0e6ce00d" />

<img width="606" height="494" alt="image" src="https://github.com/user-attachments/assets/f16db084-6ae2-428a-845e-1c157191d3f1" />

Fitted team strengths (Left: epsilon=0, Right: epsilon=1.5):

<img width="1649" height="788" alt="image" src="https://github.com/user-attachments/assets/092e7afb-db52-4f37-91ba-e440617e796a" />

The epsilon=0 one looks better to me... And from a quick check the FIFA team ratings have quite a big impact for the epsilon=1.5 one, in particular. Not using the FIFA ratings but including more history in the database could be another thing to try...
