### PR TITLE
Feature/save absences

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,19 @@ With uv installed, run these commands in a terminal to download and install AIrs
 ### Linux and macOS
 
 <details>
+  
 ```shell
 git clone https://github.com/alan-turing-institute/AIrsenal.git
 cd AIrsenal
 uv sync
 ```
+
 </details>
 
 ### Windows
+
 <details>
+  
 The best ways to run AIrsenal on Windows are either to use [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install) (WSL), which allows you to run AIrsenal in a Linux environment on your Windows system, or Docker (see below).
 
 After installing WSL, you can install uv by following the instructions [here](https://docs.astral.sh/uv/getting-started/installation/).
@@ -41,20 +45,25 @@ After installing WSL, you can install uv by following the instructions [here](ht
 You can then follow the installation instructions for Linux and macOS above (or the instructions for without uv below).
 
 You're free to try installing and using AIrsenal in Windows itself, but so far we haven't got it working. The main difficulties are with installing [jax](https://github.com/google/jax#installation) and some database/pickling errors (e.g. #165). If you do get it working we'd love to hear from you!
+
 </details>
 
 ### Use AIrsenal without uv
+
 <details>
-To use AIrsenal without uv:
+
+  To use AIrsenal without uv:
 
 ```shell
 git clone https://github.com/alan-turing-institute/AIrsenal.git
 cd AIrsenal
 pip install .
 ```
+
 </details>
 
 ### Docker
+
 <details>
 
 Rather than building and running natively on your machine, you can instead use a Docker image if you prefer.
@@ -110,12 +119,15 @@ $ docker run -it --rm -v airsenal_data:/tmp/ -e "FPL_TEAM_ID=<your_id>" -e "AIRS
 </details>
 
 ## Optional dependencies
+
 <details>
-AIrsenal has optional dependencies for plotting, running notebooks, and an in development AIrsenal API. To install them run:
+
+  AIrsenal has optional dependencies for plotting, running notebooks, and an in development AIrsenal API. To install them run:
 
 ```shell
 pip install ".[api,notebook,plot]"
 ```
+
 </details>
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ With uv installed, run these commands in a terminal to download and install AIrs
 
 ### Linux and macOS
 
+<details>
 ```shell
 git clone https://github.com/alan-turing-institute/AIrsenal.git
 cd AIrsenal
 uv sync
 ```
+</details>
 
 ### Windows
-
+<details>
 The best ways to run AIrsenal on Windows are either to use [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install) (WSL), which allows you to run AIrsenal in a Linux environment on your Windows system, or Docker (see below).
 
 After installing WSL, you can install uv by following the instructions [here](https://docs.astral.sh/uv/getting-started/installation/).
@@ -39,9 +41,10 @@ After installing WSL, you can install uv by following the instructions [here](ht
 You can then follow the installation instructions for Linux and macOS above (or the instructions for without uv below).
 
 You're free to try installing and using AIrsenal in Windows itself, but so far we haven't got it working. The main difficulties are with installing [jax](https://github.com/google/jax#installation) and some database/pickling errors (e.g. #165). If you do get it working we'd love to hear from you!
+</details>
 
 ### Use AIrsenal without uv
-
+<details>
 To use AIrsenal without uv:
 
 ```shell
@@ -49,9 +52,13 @@ git clone https://github.com/alan-turing-institute/AIrsenal.git
 cd AIrsenal
 pip install .
 ```
+</details>
 
 ### Docker
+<details>
 
+Rather than building and running natively on your machine, you can instead use a Docker image if you prefer.
+  
 Build the docker-image:
 
 ```console
@@ -100,13 +107,16 @@ $ docker run -it --rm -v airsenal_data:/tmp/ -e "FPL_TEAM_ID=<your_id>" -e "AIRS
 
 `airsenal_run_pipeline` is the default command.
 
-## Optional dependencies
+</details>
 
+## Optional dependencies
+<details>
 AIrsenal has optional dependencies for plotting, running notebooks, and an in development AIrsenal API. To install them run:
 
 ```shell
 pip install ".[api,notebook,plot]"
 ```
+</details>
 
 ## Configuration
 
@@ -245,8 +255,6 @@ If you're developing AIrsenal you may find it helpful to install it in editable 
 ```shell
 pip install -e .
 ```
-
-We're in the process of migrating to [Poetry](https://python-poetry.org/docs/). You can set up a development environment by running `poetry install` and then `poetry shell` to enter the environment.
 
 We also have a [pre-commit](https://pre-commit.com/) config to run the code quality tools we use (`flake8`, `isort`, and `black`) automatically when making commits. If you're using `poetry` it will be installed as a dev dependency, otherwise run `pip install pre-commit`. Then to setup the commit hooks:
 

--- a/airsenal/data/absences_2526.csv
+++ b/airsenal/data/absences_2526.csv
@@ -1,0 +1,111 @@
+player,player_id,season,reason,details,date_from,date_until,gw_from,gw_until,url,timestamp
+Leandro Trossard,20,2526,Groin Injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.979660
+Gabriel Fernando de Jesus,31,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.979874
+Emiliano Martínez Romero,34,2526,Suspended until 23 Aug,None,None,None,1,3,None,2025-08-11T11:51:00.980047
+Filip Marschall,37,2526,Has joined Stevenage permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.980261
+Andrés García,44,2526,Knock - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.980414
+Morgan Rogers,49,2526,Ankle injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.980565
+Ross Barkley,57,2526,Knock - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.980706
+Enzo Barrenechea,58,2526,Season-long loan to Benfica,None,None,None,1,None,None,2025-08-11T11:51:00.980847
+Owen Dodgson,75,2526,Has joined Stockport County on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.980989
+Bashir Humphreys,79,2526,Thigh injury - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.981127
+Zeki Amdouni,102,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.981273
+Norberto Murara Neto,108,2526,Has joined Botafogo permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.981411
+Justin Kluivert,123,2526,Calf injury - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.981549
+Ryan Christie,129,2526,Lack of match fitness - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.981690
+Lewis Cook,130,2526,Suspended until 30 Aug,None,None,None,1,4,None,2025-08-11T11:51:00.981824
+Luis Sinisterra Lucumí,133,2526,Lack of match fitness - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.981962
+Enes Ünal,140,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.982096
+Caoimhín Kelleher,143,2526,Knock - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.982230
+Kevin Schade,161,2526,Knock - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.982368
+Vitaly Janelt,166,2526,Heel Injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.982502
+Gustavo Nunes Fernandes Gomes,168,2526,Hamstring injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.982644
+Ryan Trevitt,175,2526,Has joined Wigan on loan for the rest of the season,None,None,None,1,None,None,2025-08-11T11:51:00.982809
+Carl Rushworth,182,2526,Has joined Coventry City on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.982947
+Kjell Scherpen,183,2526,Has joined Union SG permanently,None,None,None,1,None,None,2025-08-11T11:51:00.983084
+Pervis Estupiñán Tenorio,188,2526,Has joined AC Milan permanently,None,None,None,1,None,None,2025-08-11T11:51:00.983219
+Igor Julio dos Santos de Paulo,190,2526,Knock - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.983353
+Adam Webster,194,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.983490
+Eiran Cashin,195,2526,Has joined Birmingham on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.983624
+Solly March,200,2526,Knee injury - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.983760
+Julio Enciso Espínola,202,2526,Knee injury - Expected back 18 Oct,None,None,None,1,9,None,2025-08-11T11:51:00.983896
+Tom Watson,213,2526,Knock - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.984028
+Evan Ferguson,220,2526,Has joined AS Roma on loan for the rest of the season,None,None,None,1,None,None,2025-08-11T11:51:00.984168
+Mike Penders,225,2526,Has joined RC Strasbourg on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.984300
+Levi Samuels Colwill,230,2526,Anterior cruciate ligament - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.984433
+Benoît Badiashile Mukinayi,232,2526,Knock - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.984574
+Mamadou Sarr,234,2526,Has joined RC Strasbourg on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.984706
+Roméo Lavia,246,2526,Muscle injury - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.984840
+Mykhailo Mudryk,247,2526,Suspended - unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.984976
+Kendry Páez Andrade,250,2526,Has joined RC Strasbourg on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.985107
+Nicolas Jackson,253,2526,Suspended until 22 Aug,None,None,None,1,2,None,2025-08-11T11:51:00.985243
+Chadi Riad Dnanou,264,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.985409
+Rob Holding,266,2526,Has joined Colorado Rapids permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.985547
+Caleb Kporha,267,2526,Back injury - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.985682
+Cheick Doucouré,270,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.985818
+Daichi Kamada,273,2526,Knee injury - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.985950
+Malcolm Ebiowei,279,2526,Has joined Blackpool permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.986087
+Matheus França de Oliveira,281,2526,Muscle injury - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.986223
+David Ozoh,282,2526,Has joined Derby County on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.986356
+Eddie Nketiah,286,2526,Hamstring injury - Expected back 18 Oct,None,None,None,1,9,None,2025-08-11T11:51:00.986491
+Vitalii Mykolenko,295,2526,Muscle injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.986626
+Nathan Patterson,299,2526,Hernia - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.986760
+Harrison Armstrong,308,2526,Thigh injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.986895
+Jenson Metcalfe,312,2526,Has joined Bradford City permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.987027
+Steven Benda,319,2526,Has joined Millwall on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.987163
+Antonee Robinson,320,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.987295
+Ryan Sessegnon,332,2526,Muscle injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.987718
+Luke Harris,338,2526,Has joined Oxford United on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.987931
+Jayden Bogle,347,2526,Hip injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.988106
+Jaka Bijol,349,2526,Suspended until 23 Aug,None,None,None,1,3,None,2025-08-11T11:51:00.988257
+Sebastiaan Bornauw,350,2526,Calf injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.988440
+Charlie Crew,364,2526,Has joined Doncaster Rovers on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.988587
+Conor Bradley,383,2526,Muscle injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.988727
+Joe Gomez,384,2526,Knock - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.988869
+Luis Díaz Marulanda,391,2526,Has joined Bayern Munch permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.989006
+Ryan Gravenberch,398,2526,Suspended until 25 Aug,None,None,None,1,3,None,2025-08-11T11:51:00.989142
+Tyler Morton,403,2526,Has joined Lyon permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.989282
+Vitor de Oliveira Nunes dos Reis,422,2526,Has joined Girona on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.989417
+Phil Foden,424,2526,Knock - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.989555
+Rodrigo 'Rodri' Hernandez Cascante,431,2526,Lack of match fitness - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.989692
+Mateo Kovačić,432,2526,Achilles injury - Expected back 13 Sep,None,None,None,1,4,None,2025-08-11T11:51:00.989828
+André Onana,443,2526,Hamstring injury - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.989966
+Elyh Harrison,444,2526,On loan to Shrewsbury Town,None,None,None,1,None,None,2025-08-11T11:51:00.990099
+Lisandro Martínez,448,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.990237
+Noussair Mazraoui,449,2526,Knock - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.990372
+Marcus Rashford,462,2526,Has joined Barcelona on loan for the rest of the season,None,None,None,1,None,None,2025-08-11T11:51:00.990507
+Jack Moorhouse,475,2526,,None,None,None,1,None,None,2025-08-11T11:51:00.990644
+Joshua Zirkzee,477,2526,Knock - 50% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.990781
+Ethan Wheatley,479,2526,,None,None,None,1,None,None,2025-08-11T11:51:00.990918
+Anthony Gordon,495,2526,Ankle injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.991085
+Antoñito Cordero Campillo,502,2526,,None,None,None,1,None,None,2025-08-11T11:51:00.991223
+Joe Willock,503,2526,Calf injury - Expected back 13 Sep,None,None,None,1,4,None,2025-08-11T11:51:00.991359
+Isaac Hayden,504,2526,Has departed the club as a free agent.,None,None,None,1,None,None,2025-08-11T11:51:00.991495
+Joe White,507,2526,Has joined Leyton Orient on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.991631
+Matt Turner,514,2526,Has joined Lyon permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.991767
+Nicolás Domínguez,529,2526,Knee injury - Expected back 04 Oct,None,None,None,1,8,None,2025-08-11T11:51:00.991899
+Lewis O'Brien,530,2526,Has joined Wrexham permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.992036
+Aji Alese,546,2526,Shoulder injury - Expected back 13 Sep,None,None,None,1,4,None,2025-08-11T11:51:00.992175
+Dennis Cirkin,548,2526,Wrist Injury - Expected back 13 Sep,None,None,None,1,4,None,2025-08-11T11:51:00.992312
+Leo Fuhr Hjelde,549,2526,Achilles injury - Expected back 13 Sep,None,None,None,1,4,None,2025-08-11T11:51:00.992448
+Luke O'Nien,552,2526,Shoulder injury - Expected back 13 Sep,None,None,None,1,4,None,2025-08-11T11:51:00.992584
+Romaine Mundle,561,2526,Hamstring injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.992721
+Radu Drăgușin,587,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.992853
+Destiny Udogie,589,2526,Knee injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.992986
+Ashley Phillips,591,2526,Has joined Stoke City on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.993120
+Takai Kōta,592,2526,Foot injury - 25% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.993250
+Son Heung-min,594,2526,Has joined Los Angeles FC permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.993391
+James Maddison,596,2526,Anterior cruciate ligament - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.993523
+Dejan Kulusevski,598,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.993685
+Manor Solomon,604,2526,Calf injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.993827
+Mikey Moore,607,2526,Has joined Rangers on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.993962
+Yang Min-hyeok,609,2526,Has joined Portsmouth on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.994098
+Dominic Solanke-Mitchell,611,2526,Ankle injury - 75% chance of playing,None,None,None,1,None,None,2025-08-11T11:51:00.994229
+Will Lankshear,613,2526,Has joined Oxford United on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.994363
+Kaelan Casey,627,2526,Has joined Swansea City on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.994501
+Crysencio Summerville,631,2526,Hamstring injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.994637
+Bastien Meupiyou Menadjou,657,2526,On loan to FC Alverca,None,None,None,1,None,None,2025-08-11T11:51:00.994771
+Gonçalo Manuel Ganchinho Guedes,665,2526,Has joined Real Sociedad permanently.,None,None,None,1,None,None,2025-08-11T11:51:00.994907
+Boubacar Traoré,667,2526,Has joined FC Metz on loan for the rest of the season.,None,None,None,1,None,None,2025-08-11T11:51:00.995038
+Joe Hodge,671,2526,Signed by CD Tondela,None,None,None,1,None,None,2025-08-11T11:51:00.995185
+Leon Chiwome,675,2526,Knee injury - Unknown return date,None,None,None,1,None,None,2025-08-11T11:51:00.995321

--- a/airsenal/scripts/airsenal_run_pipeline.py
+++ b/airsenal/scripts/airsenal_run_pipeline.py
@@ -29,6 +29,7 @@ from airsenal.scripts.fill_predictedscore_table import (
 )
 from airsenal.scripts.fill_transfersuggestion_table import run_optimization
 from airsenal.scripts.make_transfers import make_transfers
+from airsenal.scripts.save_expected_absences import main as save_expected_absences
 from airsenal.scripts.set_lineup import set_lineup
 from airsenal.scripts.squad_builder import fill_initial_squad
 from airsenal.scripts.update_db import update_db
@@ -132,6 +133,11 @@ from airsenal.scripts.update_db import update_db
     help="If set, include strategies that waste free transfers",
     is_flag=True,
 )
+@click.option(
+    "--save_absences",
+    help="If set, save expected absences to 'absences_yyyy.csv' file",
+    is_flag=True,
+)
 def run_pipeline(
     num_thread: int,
     weeks_ahead: int,
@@ -149,6 +155,7 @@ def run_pipeline(
     max_transfers: int,
     max_hit: int,
     allow_unused: bool,
+    save_absences: bool,
 ) -> None:
     """
     Run the full pipeline, from setting up the database and filling
@@ -257,7 +264,9 @@ def run_pipeline(
             if not lineup_ok:
                 msg = "Problem setting the lineup"
                 raise RuntimeError(msg)
-
+        if save_absences:
+            click.echo("Saving absences to csv...")
+            save_expected_absences()
         click.echo("Pipeline finished OK!")
 
 

--- a/airsenal/scripts/save_expected_absences.py
+++ b/airsenal/scripts/save_expected_absences.py
@@ -1,0 +1,81 @@
+"""
+Week by week, we will run this script to save the information we get from the FPL API on
+players that have a <100% chance of playing the next gameweek.
+This will make it easier in the future to replay the season.
+
+The data will be written in the same way as the existing `absences_yyyy.csv`
+files, where up until the 24/25 season, these files were retrospectively created
+by scraping external websites.   From 25/26 onwards, the data will be in the
+same format, but will be the actual FPL API data.
+"""
+
+import datetime
+import os
+
+from airsenal.framework.schema import Absence, PlayerAttributes
+from airsenal.framework.utils import CURRENT_SEASON, session
+
+
+def save_absences(absence_list):
+    """
+    Write the latest data to the "absences_yyyy.csv" file
+    """
+    columns = [column.key for column in Absence.__table__.columns]
+    columns.remove("id")
+    # add player name as the first column
+    columns = ["player", *columns]
+    # first column
+    REPO_HOME = os.path.join(os.path.dirname(__file__), "..", "data")
+    output_file = os.path.join(REPO_HOME, f"absences_{CURRENT_SEASON}.csv")
+    # create file if it doesn't exist yet, and write column headers
+    if not os.path.exists(output_file):
+        with open(output_file, "w") as outfile:
+            outfile.write(",".join(columns) + "\n")
+    # Write the new data
+
+    with open(output_file, "a") as outfile:
+        for a in absence_list:
+            row = ",".join([str(a.__getattribute__(c)) for c in columns])
+            outfile.write(row + "\n")
+
+
+def player_attribute_to_absence(player_attribute):
+    """
+    Convert a PlayerAttribute row, which has data from the FPL API on player
+    unavailability, into an Absence row, which has the columns that we will
+    write to csv.
+
+    Parameters
+    ==========
+    player_attribute: PlayerAttribute row
+
+    Returns
+    =======
+    a: Absence row, with relevant details copied across
+    """
+    a = Absence()
+    a.player = player_attribute.player
+    a.player_id = player_attribute.player_id
+    a.season = player_attribute.season
+    a.gw_from = player_attribute.gameweek
+    a.gw_until = player_attribute.return_gameweek
+    a.chance_of_playing = player_attribute.chance_of_playing_next_round
+    a.reason = player_attribute.news
+    a.timestamp = datetime.datetime.now().isoformat()
+
+    return a
+
+
+def main():
+    """
+    main function, to be used as entrypoint.
+    """
+    pas = (
+        session.query(PlayerAttributes)
+        .filter(PlayerAttributes.season == CURRENT_SEASON)
+        .filter(PlayerAttributes.chance_of_playing_next_round != None)
+        .all()
+    )
+    print(f"Found {len(pas)} player absences.")
+    absences = [player_attribute_to_absence(pa) for pa in pas]
+    save_absences(absences)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ airsenal_dump_api = "airsenal.scripts.dump_api:main"
 airsenal_dump_db = "airsenal.scripts.dump_db_contents:main"
 airsenal_scrape_transfermarkt = "airsenal.scripts.scrape_transfermarkt:main"
 airsenal_plot = "airsenal.scripts.plot_league_standings:main"
+airsenal_save_absences = "airsenal.scripts.save_expected_absences:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
add script `save_expected_absences.py` that will write the injury/suspension data that we get from the FPL API and fill into PlayerAttributes, into the "Absence" format, and write it to `absences_{CURRENT_SEASON}.csv`, so that it can be used in the future to replay the season.
Also add entrypoint to `pyproject.toml` and add option to run this as a flag in `airsenal_run_pipeline`.