### PR TITLE
Fix SQLAlchemy error: use player_id instead of Player object in add_transaction

### DIFF
--- a/airsenal/framework/transaction_utils.py
+++ b/airsenal/framework/transaction_utils.py
@@ -180,7 +180,7 @@ def fill_initial_squad(
             price = first_gw_data[0]["value"]
 
         add_transaction(
-            player,
+            player.player_id,
             starting_gw,
             1,
             price,


### PR DESCRIPTION
## Problem Description

`airsenal_update_db` command was failing with an SQLAlchemy `ProgrammingError` during initial squad population. Error occurred because a `Player` object was being passed to the `add_transaction()` function instead of the expected `player_id`.

**Error message:**
```
sqlite3.ProgrammingError: Error binding parameter 1: type 'Player' is not supported
```

## Changes Made

- **File:** `airsenal/framework/transaction_utils.py:183`
- **Change:** Modified `add_transaction(player, ...)` to `add_transaction(player.player_id, ...)`

Ensures the `Transaction` table receives correct integer `player_id` field as expected by the database schema.

## Testing

- [x] Verified fix resolves SQLAlchemy error
- [x] `airsenal_update_db` command runs successfully
- [x] Initial squad population completes without errors

## Review Focus

Please focus on:
- Correctness of the fix in the database transaction logic