### PR TITLE
fix(scripts): removing the deprecated infer_datetime_format argument

### DIFF
--- a/airsenal/scripts/fill_absence_table.py
+++ b/airsenal/scripts/fill_absence_table.py
@@ -19,9 +19,7 @@ def load_absences(season: str, dbsession: Session) -> None:
     path = os.path.join(
         os.path.dirname(__file__), "..", "data", f"absences_{season}.csv"
     )
-    absences = pd.read_csv(
-        path, parse_dates=["from", "until"], infer_datetime_format=True
-    )
+    absences = pd.read_csv(path, parse_dates=["from", "until"]) 
 
     for _, row in tqdm(absences.iterrows(), total=absences.shape[0]):
         p = get_player(row["player"], dbsession=dbsession)


### PR DESCRIPTION
- Add automatic main entry in fill_db_init.py so running the script will append --clean and call main(), enabling automatic clean database initialization.
- Import sys to support argv modification.
- Simplify CSV loading in fill_absence_table.py by removing the deprecated infer_datetime_format argument from pd.read_csv.