### PR TITLE
Add type annotations to framework and scripts

### DIFF
--- a/airsenal/framework/FPL_scoring_rules.py
+++ b/airsenal/framework/FPL_scoring_rules.py
@@ -21,7 +21,7 @@ def_cons_required = {"GK": 999, "DEF": 10, "MID": 12, "FWD": 12}
 points_for_def_cons = 2
 
 
-def get_appearance_points(minutes):
+def get_appearance_points(minutes: int | float) -> float:
     """
     get points for being on the pitch at all, and more for being on
     for most of the match.

--- a/airsenal/framework/api_utils.py
+++ b/airsenal/framework/api_utils.py
@@ -2,8 +2,8 @@
 Functions used by the AIrsenal API
 """
 
-from flask import jsonify
-from sqlalchemy.orm import scoped_session
+from flask import Response, jsonify
+from sqlalchemy.orm.session import Session
 
 from airsenal.framework.optimization_transfers import (
     make_optimum_double_transfer,
@@ -26,14 +26,12 @@ from airsenal.framework.utils import (
     list_teams,
 )
 
-DBSESSION = scoped_session(session)
+
+def remove_db_session(dbsession: Session = session) -> None:
+    dbsession.close()
 
 
-def remove_db_session(dbsession=DBSESSION):
-    dbsession.remove()
-
-
-def create_response(orig_response):
+def create_response(orig_response: dict | list) -> Response:
     """
     Add headers to the response
     """
@@ -45,7 +43,7 @@ def create_response(orig_response):
     return response
 
 
-def reset_session_squad(session_id, dbsession=DBSESSION):
+def reset_session_squad(session_id: str, dbsession: Session = session) -> bool:
     """
     remove any rows with the given session ID and add a new budget of
     100M
@@ -62,7 +60,9 @@ def reset_session_squad(session_id, dbsession=DBSESSION):
     return True
 
 
-def list_players_for_api(team, position, dbsession=DBSESSION):
+def list_players_for_api(
+    team: str, position: str, dbsession: Session = session
+) -> list:
     """
     List players.  Just pass on to utils.list_players but
     specify the dbsession.
@@ -70,7 +70,7 @@ def list_players_for_api(team, position, dbsession=DBSESSION):
     return list_players(team=team, position=position, dbsession=dbsession)
 
 
-def list_teams_for_api(dbsession=DBSESSION):
+def list_teams_for_api(dbsession: Session = session) -> list:
     """
     List teams.  Just pass on to utils.list_teams but
     specify the season and  dbsession.
@@ -80,12 +80,12 @@ def list_teams_for_api(dbsession=DBSESSION):
     return all_teams
 
 
-def combine_player_info(player_id, dbsession=DBSESSION):
+def combine_player_info(player_id: int, dbsession: Session = session) -> dict:
     """
     Get player's name, club, recent scores, upcoming fixtures, and
     upcoming predictions if available
     """
-    info_dict = {"player_id": player_id}
+    info_dict: dict = {"player_id": player_id}
     p = get_player(player_id, dbsession=dbsession)
     if p is None:
         msg = f"Player with id {player_id} not found"
@@ -115,7 +115,9 @@ def combine_player_info(player_id, dbsession=DBSESSION):
     return info_dict
 
 
-def add_session_player(player_id, session_id, dbsession=DBSESSION):
+def add_session_player(
+    player_id: int, session_id: str, dbsession: Session = session
+) -> bool:
     """
     Add a row in the SessionSquad table.
     """
@@ -128,7 +130,9 @@ def add_session_player(player_id, session_id, dbsession=DBSESSION):
     return True
 
 
-def remove_session_player(player_id, session_id, dbsession=DBSESSION):
+def remove_session_player(
+    player_id: int | str, session_id: str, dbsession: Session = session
+) -> bool:
     """
     Remove row from SessionSquad table.
     """
@@ -146,8 +150,11 @@ def remove_session_player(player_id, session_id, dbsession=DBSESSION):
 
 
 def list_players_teams_prices(
-    position="all", team="all", dbsession=DBSESSION, gameweek=NEXT_GAMEWEEK
-):
+    position: str = "all",
+    team: str = "all",
+    dbsession: Session = session,
+    gameweek: int = NEXT_GAMEWEEK,
+) -> list[str]:
     """
     Return a list of players, each with their current team and price
     """
@@ -163,7 +170,7 @@ def list_players_teams_prices(
     ]
 
 
-def get_session_budget(session_id, dbsession=DBSESSION):
+def get_session_budget(session_id: str, dbsession: Session = session) -> int:
     """
     query the sessionbudget table in the db - there should hopefully
     be one and only one row for this session_id
@@ -176,7 +183,9 @@ def get_session_budget(session_id, dbsession=DBSESSION):
     return sb[0].budget
 
 
-def set_session_budget(budget, session_id, dbsession=DBSESSION):
+def set_session_budget(
+    budget: int, session_id: str, dbsession: Session = session
+) -> bool:
     """
     delete the existing entry for this session_id in the sessionbudget table,
     then enter a new row
@@ -191,24 +200,21 @@ def set_session_budget(budget, session_id, dbsession=DBSESSION):
     return True
 
 
-def get_session_players(session_id, dbsession=DBSESSION):
+def get_session_players(session_id: str, dbsession: Session = session) -> list[dict]:
     """
     query the dbsession for the list of players with the requested player_id
     """
     players = dbsession.query(SessionSquad).filter_by(session_id=session_id).all()
-    return [
-        {
-            "id": p.player_id,
-            "name": dbsession.query(Player)
-            .filter_by(player_id=p.player_id)
-            .first()
-            .name,
-        }
-        for p in players
-    ]
+    result = []
+    for p in players:
+        player_row = dbsession.query(Player).filter_by(player_id=p.player_id).first()
+        result.append(
+            {"id": p.player_id, "name": player_row.name if player_row else ""}
+        )
+    return result
 
 
-def validate_session_squad(session_id, dbsession=DBSESSION):
+def validate_session_squad(session_id: str, dbsession: Session = session) -> bool:
     """
     get the list of player_ids for this session_id, and see if we can
     make a valid 15-player squad out of it
@@ -226,7 +232,9 @@ def validate_session_squad(session_id, dbsession=DBSESSION):
     return True
 
 
-def fill_session_squad(team_id, session_id, dbsession=DBSESSION):
+def fill_session_squad(
+    team_id: int, session_id: str, dbsession: Session = session
+) -> list[int]:
     """
     Use the FPL API to get list of players in an FPL squad with id=team_id,
     then fill the session squad with these players.
@@ -247,7 +255,12 @@ def fill_session_squad(team_id, session_id, dbsession=DBSESSION):
     return player_ids
 
 
-def get_session_prediction(player_id, gw=None, pred_tag=None, dbsession=DBSESSION):
+def get_session_prediction(
+    player_id: int,
+    gw: int | None = None,
+    pred_tag: str | None = None,
+    dbsession: Session = session,
+) -> dict:
     """
     Query the fixture and predictedscore tables for a specified player
     """
@@ -259,11 +272,13 @@ def get_session_prediction(player_id, gw=None, pred_tag=None, dbsession=DBSESSIO
         "predicted_score": get_predicted_points_for_player(
             player_id, pred_tag, CURRENT_SEASON, dbsession
         )[gw],
-        "fixture": get_next_fixture_for_player(player_id, CURRENT_SEASON, dbsession),
+        "fixture": get_next_fixture_for_player(
+            player_id, CURRENT_SEASON, dbsession=dbsession
+        ),
     }
 
 
-def get_session_predictions(session_id, dbsession=DBSESSION):
+def get_session_predictions(session_id: str, dbsession: Session = session) -> dict:
     """
     Query the fixture and predictedscore tables for all
     players in our session squad
@@ -274,7 +289,9 @@ def get_session_predictions(session_id, dbsession=DBSESSION):
     return {pid: get_session_prediction(pid, gw, pred_tag, dbsession) for pid in pids}
 
 
-def best_transfer_suggestions(n_transfer, session_id, dbsession=DBSESSION):
+def best_transfer_suggestions(
+    n_transfer: int | str, session_id: str, dbsession: Session = session
+) -> dict:
     """
     Use our predicted playerscores to suggest the best transfers.
     """

--- a/airsenal/framework/aws_utils.py
+++ b/airsenal/framework/aws_utils.py
@@ -15,7 +15,7 @@ from airsenal.framework.fpl_team_utils import (
 from airsenal.framework.schema import Player, TransferSuggestion, session
 
 
-def download_sqlite_file():
+def download_sqlite_file() -> str:
     """
     get from S3 using boto3
     """
@@ -35,7 +35,7 @@ def download_sqlite_file():
         return f"Problem downloading file {e}"
 
 
-def get_league_standings_string():
+def get_league_standings_string() -> str:
     """
     Query the FPL API for our mini-league.
     """
@@ -55,7 +55,7 @@ def get_league_standings_string():
         return f"Problem {e}"
 
 
-def get_suggestions_string():
+def get_suggestions_string() -> str:
     """
     Query the suggested_transfers table and format the output.
     """
@@ -73,7 +73,7 @@ def get_suggestions_string():
         return f"Problem with the query {e}"
 
 
-def build_suggestion_string(session, TransferSuggestion, Player):
+def build_suggestion_string(session, TransferSuggestion, Player) -> str:
     all_rows = session.query(TransferSuggestion).all()
     last_timestamp = all_rows[-1].timestamp
     rows = (
@@ -99,7 +99,7 @@ def build_suggestion_string(session, TransferSuggestion, Player):
     return output_string
 
 
-def get_score_ranking_string(query, gameweek=None):
+def get_score_ranking_string(query: str, gameweek: int | None = None) -> str:
     """
     query the FPL API for team history.
     """

--- a/airsenal/framework/bpl_interface.py
+++ b/airsenal/framework/bpl_interface.py
@@ -108,7 +108,7 @@ def get_training_data(
     gameweek: int,
     dbsession: Session,
     ratings: bool = True,
-):
+) -> dict[str, np.ndarray | dict[str, np.ndarray]]:
     """Get training data for team model, optionally including FIFA ratings
     as covariates if ratings is True. If time_decay is None, do not include
     exponential time decay in model.

--- a/airsenal/framework/data_fetcher.py
+++ b/airsenal/framework/data_fetcher.py
@@ -17,6 +17,7 @@ import time
 import traceback
 import uuid
 import warnings
+from typing import overload
 
 from curl_cffi import requests
 
@@ -45,11 +46,11 @@ CLIENT_ID = "bfcbaf69-aade-4c1b-8f00-c1cb8a193030"
 STANDARD_CONNECTION_ID = "867ed4363b2bc21c860085ad2baa817d"
 
 
-def generate_code_verifier():
+def generate_code_verifier() -> str:
     return secrets.token_urlsafe(64)[:128]
 
 
-def generate_code_challenge(verifier):
+def generate_code_challenge(verifier: str) -> str:
     digest = hashlib.sha256(verifier.encode()).digest()
     return base64.urlsafe_b64encode(digest).decode().rstrip("=")
 
@@ -60,7 +61,7 @@ class FPLDataFetcher:
     or retrieve it if not already cached.
     """
 
-    def __init__(self, fpl_team_id: int | None = None, rsession=None):
+    def __init__(self, fpl_team_id: int | None = None, rsession=None) -> None:
         self.rsession = rsession or requests.Session(impersonate="chrome")
         self.headers: dict[str, str] = {}
         self.logged_in = False
@@ -74,9 +75,9 @@ class FPLDataFetcher:
         self.fpl_team_history_data: dict = {}
         # transfer history data is a dict, keyed by fpl_team_id
         self.fpl_transfer_history_data: dict = {}
-        self.fpl_league_data: dict = {}
+        self.fpl_league_data: dict | None = None
         self.fpl_team_data: dict = {}  # players in squad, by gameweek
-        self.fixture_data: dict = {}
+        self.fixture_data: list = []
 
         self.FPL_TEAM_ID = FPL_TEAM_ID if fpl_team_id is None else fpl_team_id
         self.FPL_LOGIN = FPL_LOGIN
@@ -97,7 +98,7 @@ class FPLDataFetcher:
         self.FPL_FIXTURE_URL = f"{API_HOME}/fixtures/"
         self.FPL_MYTEAM_URL = API_HOME + "/my-team/{}/"
 
-    def get_fpl_credentials(self):
+    def get_fpl_credentials(self) -> None:
         """
         If we didn't have FPL_LOGIN and FPL_PASSWORD available as files in
         AIRSENAL_HOME or as environment variables, prompt the user for them.
@@ -122,7 +123,7 @@ class FPLDataFetcher:
             save_env("FPL_LOGIN", self.FPL_LOGIN)
             save_env("FPL_PASSWORD", self.FPL_PASSWORD)
 
-    def login(self):
+    def login(self) -> None:
         """
         only needed for accessing mini-league data, or team info for current gw.
         """
@@ -328,7 +329,9 @@ class FPLDataFetcher:
             )
             return
 
-    def _set_login_failed(self, exception: Exception | None = None, msg: str = ""):
+    def _set_login_failed(
+        self, exception: Exception | None = None, msg: str = ""
+    ) -> None:
         self.login_failed = True
         exc_str = (
             "".join(traceback.TracebackException.from_exception(exception).format())
@@ -343,7 +346,7 @@ class FPLDataFetcher:
         )
         warnings.warn(f"{msg}\n{exc_str}\n{help}", stacklevel=3)
 
-    def get_current_squad_data(self, fpl_team_id=None):
+    def get_current_squad_data(self, fpl_team_id: int | None = None) -> dict:
         """
         Requires login.  Return the current squad data, including
         "picks", bank, and free transfers.
@@ -359,10 +362,10 @@ class FPLDataFetcher:
 
         self.login()
         url = self.FPL_MYTEAM_URL.format(fpl_team_id)
-        self.current_squad_data[fpl_team_id] = self._get_request(url)
+        self.current_squad_data[fpl_team_id] = self._get_dict_request(url)
         return self.current_squad_data[fpl_team_id]
 
-    def get_current_picks(self, fpl_team_id=None):
+    def get_current_picks(self, fpl_team_id: int | None = None) -> list:
         """
         Returns the players picked for the upcoming gameweek, including
         purchase and selling prices, and whether they are subs or not.
@@ -371,7 +374,7 @@ class FPLDataFetcher:
         squad_data = self.get_current_squad_data(fpl_team_id)
         return squad_data["picks"]
 
-    def get_num_free_transfers(self, fpl_team_id=None):
+    def get_num_free_transfers(self, fpl_team_id: int | None = None) -> int:
         """
         Returns the number of free transfers for the upcoming gameweek.
         Requires login
@@ -381,7 +384,7 @@ class FPLDataFetcher:
             0, squad_data["transfers"]["limit"] - squad_data["transfers"]["made"]
         )
 
-    def get_current_bank(self, fpl_team_id=None):
+    def get_current_bank(self, fpl_team_id: int | None = None) -> int:
         """
         Returns the remaining bank (in 0.1M) for the upcoming gameweek.
         Requires login
@@ -389,7 +392,7 @@ class FPLDataFetcher:
         squad_data = self.get_current_squad_data(fpl_team_id)
         return squad_data["transfers"]["bank"]
 
-    def get_available_chips(self, fpl_team_id=None):
+    def get_available_chips(self, fpl_team_id: int | None = None) -> list[str]:
         """
         Returns a list of chips that are available to be played in upcoming gameweek.
         Requires login
@@ -401,17 +404,19 @@ class FPLDataFetcher:
             if chip["status_for_entry"] == "available"
         ]
 
-    def get_current_summary_data(self):
+    def get_current_summary_data(self) -> dict:
         """
         return cached data if present, otherwise retrieve it
         from the API.
         """
         if self.current_summary_data:
             return self.current_summary_data
-        self.current_summary_data = self._get_request(self.FPL_SUMMARY_API_URL)
+        self.current_summary_data = self._get_dict_request(self.FPL_SUMMARY_API_URL)
         return self.current_summary_data
 
-    def get_fpl_team_data(self, gameweek, fpl_team_id=None):
+    def get_fpl_team_data(
+        self, gameweek: int | None = None, fpl_team_id: int | None = None
+    ) -> dict:
         """
         Use FPL team id to get team data from the FPL API.
         If no fpl_team_id is specified, we assume it is 'our' team
@@ -422,14 +427,14 @@ class FPLDataFetcher:
         if not fpl_team_id:
             fpl_team_id = self.FPL_TEAM_ID
         url = self.FPL_TEAM_URL.format(fpl_team_id, gameweek)
-        fpl_team_data = self._get_request(
+        fpl_team_data = self._get_dict_request(
             url, err_msg=f"Unable to access FPL team API {url}"
         )
         if not fpl_team_id:
             self.fpl_team_data[gameweek] = fpl_team_data
         return fpl_team_data
 
-    def get_fpl_team_history_data(self, team_id=None):
+    def get_fpl_team_history_data(self, team_id: int | None = None) -> dict:
         """
         Use our team id to get history data from the FPL API.
         """
@@ -438,12 +443,12 @@ class FPLDataFetcher:
         if not team_id:
             team_id = self.FPL_TEAM_ID
         url = self.FPL_HISTORY_URL.format(team_id)
-        self.fpl_team_history_data = self._get_request(
+        self.fpl_team_history_data = self._get_dict_request(
             url, err_msg="Unable to access FPL team history API"
         )
         return self.fpl_team_history_data
 
-    def get_fpl_transfer_data(self, fpl_team_id=None):
+    def get_fpl_transfer_data(self, fpl_team_id: int | None = None) -> list:
         """
         Get our transfer history from the FPL API.
         """
@@ -473,7 +478,7 @@ class FPLDataFetcher:
         )
         return self.fpl_transfer_history_data[fpl_team_id]
 
-    def get_fpl_league_data(self):
+    def get_fpl_league_data(self) -> dict | None:
         """
         Use our league id to get history data from the FPL API.
         """
@@ -481,14 +486,10 @@ class FPLDataFetcher:
             return self.fpl_league_data
 
         self.login()
-        r = self._get_request(self.FPL_LEAGUE_URL)
-        if r.status_code != 200:
-            print("Unable to access FPL league API")
-            return None
-        self.fpl_league_data = json.loads(r.content.decode("utf-8"))
+        self.fpl_league_data = self._get_dict_request(self.FPL_LEAGUE_URL)
         return self.fpl_league_data
 
-    def get_event_data(self):
+    def get_event_data(self) -> dict:
         """
         return a dict of gameweeks - whether they are finished or not, and
         the transfer deadline.
@@ -504,7 +505,7 @@ class FPLDataFetcher:
             }
         return self.current_event_data
 
-    def get_player_summary_data(self):
+    def get_player_summary_data(self) -> dict:
         """
         Use the current_data to build a dictionary, keyed by player_api_id
         in order to retrieve a player without having to loop through
@@ -518,7 +519,7 @@ class FPLDataFetcher:
             self.current_player_data[player["id"]] = player
         return self.current_player_data
 
-    def get_current_team_data(self):
+    def get_current_team_data(self) -> dict:
         """
         Use the current_data to build a dictionary keyed by team code,
         in order to retrieve a player's team without looping through the
@@ -532,7 +533,19 @@ class FPLDataFetcher:
             self.current_team_data[team["code"]] = team
         return self.current_team_data
 
-    def get_gameweek_data_for_player(self, player_api_id, gameweek=None):
+    @overload
+    def get_gameweek_data_for_player(
+        self, player_api_id: int, gameweek: None = None
+    ) -> dict: ...
+
+    @overload
+    def get_gameweek_data_for_player(
+        self, player_api_id: int, gameweek: int
+    ) -> list: ...
+
+    def get_gameweek_data_for_player(
+        self, player_api_id: int, gameweek: int | None = None
+    ) -> dict | list:
         """
         return cached data if available, otherwise
         fetch it from API.
@@ -544,7 +557,7 @@ class FPLDataFetcher:
             if (not gameweek) or (
                 gameweek not in self.player_gameweek_data[player_api_id]
             ):
-                player_detail = self._get_request(
+                player_detail = self._get_dict_request(
                     self.FPL_DETAIL_URL.format(player_api_id),
                     f"Error retrieving data for player {player_api_id}",
                 )
@@ -561,41 +574,41 @@ class FPLDataFetcher:
             return []
         return self.player_gameweek_data[player_api_id][gameweek]
 
-    def get_fixture_data(self):
+    def get_fixture_data(self) -> list:
         """
         Get the fixture list from the FPL API.
         """
         if not self.fixture_data:
-            self.fixture_data = self._get_request(self.FPL_FIXTURE_URL)
+            self.fixture_data = self._get_list_request(self.FPL_FIXTURE_URL)
         return self.fixture_data
 
-    def get_transfer_deadlines(self):
+    def get_transfer_deadlines(self) -> list[str]:
         """
         Get a list of transfer deadlines.
         """
-        summary_data = self._get_request(self.FPL_SUMMARY_API_URL)
+        summary_data = self._get_dict_request(self.FPL_SUMMARY_API_URL)
         return [
             ev["deadline_time"]
             for ev in summary_data["events"]
             if "deadline_time" in ev
         ]
 
-    def get_lineup(self):
+    def get_lineup(self) -> dict:
         """
         Retrieve up to date lineup from api
         """
         self.login()
         team_url = self.FPL_MYTEAM_URL.format(self.FPL_TEAM_ID)
-        return self._get_request(team_url)
+        return self._get_dict_request(team_url)
 
-    def post_lineup(self, payload):
+    def post_lineup(self, payload: list) -> None:
         """Set the lineup for a specific team"""
         self.login()
-        payload = {"chip": None, "picks": payload}
+        request_payload: dict = {"chip": None, "picks": payload}
         team_url = self.FPL_MYTEAM_URL.format(self.FPL_TEAM_ID)
         self._post_data(
             team_url,
-            payload,
+            request_payload,
             err_msg=(
                 "Failed to set lineup. Make the changes manually on the web-site if "
                 "needed"
@@ -603,7 +616,7 @@ class FPLDataFetcher:
         )
         print("Lineup set!")
 
-    def post_transfers(self, transfer_payload):
+    def post_transfers(self, transfer_payload: dict) -> None:
         """Make transfers via the API.
 
         WARNING: This can't be undone and may incur points hits. It also doesn't support
@@ -623,9 +636,35 @@ class FPLDataFetcher:
         )
         print("Transfers made!")
 
+    def _get_dict_request(
+        self,
+        url: str,
+        err_msg: str = "Unable to access FPL API",
+        attempts: int = 3,
+        **params,
+    ) -> dict:
+        result = self._get_request(url, err_msg, attempts, **params)
+        assert isinstance(result, dict)
+        return result
+
+    def _get_list_request(
+        self,
+        url: str,
+        err_msg: str = "Unable to access FPL API",
+        attempts: int = 3,
+        **params,
+    ) -> list:
+        result = self._get_request(url, err_msg, attempts, **params)
+        assert isinstance(result, list)
+        return result
+
     def _get_request(
-        self, url, err_msg="Unable to access FPL API", attempts=3, **params
-    ):
+        self,
+        url: str,
+        err_msg: str = "Unable to access FPL API",
+        attempts: int = 3,
+        **params,
+    ) -> dict | list:
         tries = 0
         r = None
         while tries < attempts:
@@ -659,7 +698,12 @@ class FPLDataFetcher:
         )
         raise RuntimeError(msg)
 
-    def _post_data(self, url, data, err_msg="Failed to post data to FPL API"):
+    def _post_data(
+        self,
+        url: str,
+        data: dict | list,
+        err_msg: str = "Failed to post data to FPL API",
+    ) -> None:
         headers = {
             "Content-Type": "application/json; charset=UTF-8",
             "X-Requested-With": "XMLHttpRequest",

--- a/airsenal/framework/env.py
+++ b/airsenal/framework/env.py
@@ -7,6 +7,8 @@ from typing import TypeVar
 
 from platformdirs import user_data_dir
 
+_R = TypeVar("_R")
+
 # Cross-platform data directory
 if "AIRSENAL_HOME" in os.environ:
     AIRSENAL_HOME = Path(os.environ["AIRSENAL_HOME"])
@@ -28,11 +30,11 @@ AIRSENAL_ENV_KEYS = [
 ]
 
 
-def check_valid_key(func):
+def check_valid_key(func: Callable[..., _R]) -> Callable[..., _R]:
     """decorator to pre-check whether we are using a valid AIrsenal key in env
     get/save/del functions"""
 
-    def wrapper(key, *args, **kwargs):
+    def wrapper(key: str, *args, **kwargs) -> _R:
         if key not in AIRSENAL_ENV_KEYS:
             msg = f"{key} is not a known AIrsenal environment variable"
             raise KeyError(msg)
@@ -42,13 +44,13 @@ def check_valid_key(func):
 
 
 @check_valid_key
-def save_env(key, value):
+def save_env(key: str, value: str) -> None:
     with open(AIRSENAL_HOME / key, "w") as f:
         f.write(value)
 
 
 @check_valid_key
-def delete_env(key):
+def delete_env(key: str) -> None:
     if os.path.exists(AIRSENAL_HOME / key):
         os.remove(AIRSENAL_HOME / key)
     if key in os.environ:

--- a/airsenal/framework/fpl_team_utils.py
+++ b/airsenal/framework/fpl_team_utils.py
@@ -5,37 +5,39 @@ Functions to get data on specified FPL teams and leagues
 from airsenal.framework.utils import fetcher
 
 
-def get_overall_points(gameweek=None):
+def get_overall_points(gameweek: int | None = None) -> int:
     """
     Get our total points
     """
     data = fetcher.get_fpl_team_data(gameweek=gameweek)
-    if not gameweek:
+    if gameweek is None:
         return data["entry"]["summary_overall_points"]
-    if isinstance(gameweek, int) and gameweek <= len(data["history"]):
+    if gameweek <= len(data["history"]):
         return data["history"][gameweek - 1]["points"]
     print("Unknown gameweek")
     return 0
 
 
-def get_overall_ranking(gameweek=None):
+def get_overall_ranking(gameweek: int | None = None) -> int:
     """
     Get our overall ranking
     """
     data = fetcher.get_fpl_team_data(gameweek=gameweek)
-    if not gameweek:
+    if gameweek is None:
         return data["entry"]["summary_overall_rank"]
-    if isinstance(gameweek, int) and gameweek <= len(data["history"]):
+    if gameweek <= len(data["history"]):
         return data["history"][gameweek - 1]["rank"]
     print("Unknown gameweek")
     return 0
 
 
-def get_league_standings():
+def get_league_standings() -> tuple[str, list[dict]]:
     """
     Get stuff about our mini-league
     """
     data = fetcher.get_fpl_league_data()
+    if data is None:
+        return "", []
     team_name = data["league"]["name"]
     standings = [
         {"name": s["entry_name"], "manager": s["player_name"], "points": s["total"]}

--- a/airsenal/framework/multiprocessing_utils.py
+++ b/airsenal/framework/multiprocessing_utils.py
@@ -13,7 +13,7 @@ import os
 from multiprocessing.queues import Queue
 
 
-def set_multiprocessing_start_method():
+def set_multiprocessing_start_method() -> None:
     """To fix change of default behaviour in multiprocessing on Python 3.8 and later
     on MacOS. Python 3.8 and later start processess using spawn by default, see:
     https://docs.python.org/3.8/library/multiprocessing.html#contexts-and-start-methods
@@ -44,16 +44,16 @@ class SharedCounter:
     http://eli.thegreenplace.net/2012/01/04/shared-counter-with-pythons-multiprocessing/
     """
 
-    def __init__(self, n=0):
+    def __init__(self, n: int = 0) -> None:
         self.count = multiprocessing.Value("i", n)
 
-    def increment(self, n=1):
+    def increment(self, n: int = 1) -> None:
         """Increment the counter by n (default = 1)"""
         with self.count.get_lock():
             self.count.value += n
 
     @property
-    def value(self):
+    def value(self) -> int:
         """Return the value of the counter"""
         return self.count.value
 
@@ -71,22 +71,22 @@ class CustomQueue(Queue):
     qsize() and empty().
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(ctx=multiprocessing.get_context())
         self.size = SharedCounter(0)
 
-    def put(self, *args, **kwargs):
+    def put(self, *args, **kwargs) -> None:
         self.size.increment(1)
         super().put(*args, **kwargs)
 
-    def get(self, *args, **kwargs):
+    def get(self, *args, **kwargs) -> object:
         self.size.increment(-1)
         return super().get(*args, **kwargs)
 
-    def qsize(self):
+    def qsize(self) -> int:
         """Reliable implementation of multiprocessing.Queue.qsize()"""
         return self.size.value
 
-    def empty(self):
+    def empty(self) -> bool:
         """Reliable implementation of multiprocessing.Queue.empty()"""
         return not self.qsize()

--- a/airsenal/framework/optimization_squad.py
+++ b/airsenal/framework/optimization_squad.py
@@ -57,17 +57,17 @@ class SquadOpt:
 
     def __init__(
         self,
-        gw_range,
-        tag,
-        budget=1000,
-        dummy_sub_cost=45,
-        season=CURRENT_SEASON,
-        bench_boost_gw=None,
-        triple_captain_gw=None,
-        remove_zero=True,  # don't consider players with predicted pts of zero
-        players_per_position=TOTAL_PER_POSITION,
-        sub_weights=DEFAULT_SUB_WEIGHTS,
-    ):
+        gw_range: list[int],
+        tag: str,
+        budget: int = 1000,
+        dummy_sub_cost: int = 45,
+        season: str = CURRENT_SEASON,
+        bench_boost_gw: int | None = None,
+        triple_captain_gw: int | None = None,
+        remove_zero: bool = True,
+        players_per_position: dict[str, int] = TOTAL_PER_POSITION,
+        sub_weights: dict = DEFAULT_SUB_WEIGHTS,
+    ) -> None:
         self.season = season
         self.gw_range = gw_range
         self.start_gw = min(gw_range)
@@ -92,7 +92,7 @@ class SquadOpt:
         # Setup DEAP toolbox
         self._setup_deap()
 
-    def _setup_deap(self):
+    def _setup_deap(self) -> None:
         """Setup DEAP genetic algorithm components."""
         # Create fitness and individual classes
         # We want to maximize fitness, so weights=(1.0,)
@@ -113,7 +113,7 @@ class SquadOpt:
         # Store mutation bounds for later use in optimize method
         self.low_bounds, self.up_bounds = self._get_mutation_bounds()
 
-    def _create_individual(self):
+    def _create_individual(self) -> list:
         """Create a valid individual (chromosome) representing a squad selection."""
         individual = []
 
@@ -130,7 +130,7 @@ class SquadOpt:
 
         return creator.Individual(individual)
 
-    def _get_mutation_bounds(self):
+    def _get_mutation_bounds(self) -> tuple[list[int], list[int]]:
         """Get lower and upper bounds for each gene for mutation."""
         low_bounds = []
         up_bounds = []
@@ -188,7 +188,7 @@ class SquadOpt:
 
         return (score,)
 
-    def _get_player_list(self):
+    def _get_player_list(self) -> tuple[list[Player], dict[str, tuple[int, int]]]:
         """Get list of active players at the start of the gameweek range,
         and the id range of players for each position.
         """
@@ -208,20 +208,21 @@ class SquadOpt:
         }
         return players, position_idx
 
-    def _remove_zero_pts(self):
+    def _remove_zero_pts(self) -> None:
         """Exclude players with zero predicted points."""
         players: list[Player] = []
         # change_idx stores the indices of where the player positions change in the new
         # player list
         change_idx = [0]
-        last_pos = self.positions[0]
+        last_pos: str = self.positions[0]
         for p in self.players:
             gw_pts = get_predicted_points_for_player(p, self.tag, season=self.season)
             total_pts = sum(pts for gw, pts in gw_pts.items() if gw in self.gw_range)
             if total_pts > 0:
-                if p.position(self.season) != last_pos:
+                p_pos = p.position(self.season)
+                if p_pos is not None and p_pos != last_pos:
                     change_idx.append(len(players))
-                    last_pos = p.position(self.season)
+                    last_pos = p_pos
                 players.append(p)
         change_idx.append(len(players))
 
@@ -233,7 +234,7 @@ class SquadOpt:
         self.players = players
         self.position_idx = position_idx
 
-    def _get_dummy_per_position(self):
+    def _get_dummy_per_position(self) -> dict[str, int]:
         """No. of dummy players per position needed to complete the squad (if not
         optimising the full squad)
         """
@@ -330,26 +331,26 @@ class SquadOpt:
 
 
 def make_new_squad(
-    gw_range,
-    tag,
-    budget=1000,
-    players_per_position=TOTAL_PER_POSITION,
-    season=CURRENT_SEASON,
-    verbose=True,
-    bench_boost_gw=None,
-    triple_captain_gw=None,
-    remove_zero=True,  # don't consider players with predicted pts of zero
-    sub_weights=DEFAULT_SUB_WEIGHTS,
-    dummy_sub_cost=45,
-    population_size=100,
-    generations=100,
-    crossover_prob=0.7,
-    mutation_prob=0.3,
-    crossover_indpb=0.5,
-    mutation_indpb=0.1,
-    tournament_size=3,
-    random_state=None,
-):
+    gw_range: list[int],
+    tag: str,
+    budget: int = 1000,
+    players_per_position: dict[str, int] = TOTAL_PER_POSITION,
+    season: str = CURRENT_SEASON,
+    verbose: bool = True,
+    bench_boost_gw: int | None = None,
+    triple_captain_gw: int | None = None,
+    remove_zero: bool = True,
+    sub_weights: dict = DEFAULT_SUB_WEIGHTS,
+    dummy_sub_cost: int = 45,
+    population_size: int = 100,
+    generations: int = 100,
+    crossover_prob: float = 0.7,
+    mutation_prob: float = 0.3,
+    crossover_indpb: float = 0.5,
+    mutation_indpb: float = 0.1,
+    tournament_size: int = 3,
+    random_state: int | None = None,
+) -> Squad:
     """Optimize a full initial squad using DEAP genetic algorithm.
 
     Parameters
@@ -440,11 +441,12 @@ def make_new_squad(
     for idx in best_individual:
         if verbose:
             player = opt_squad.players[int(idx)]
+            player_price = player.price(season, 1)
             print(
                 player.position(season),
                 player,
                 player.team(season, 1),
-                player.price(season, 1) / 10,
+                player_price / 10 if player_price is not None else "N/A",
             )
         squad.add_player(
             opt_squad.players[int(idx)].player_id,

--- a/airsenal/framework/optimization_transfers.py
+++ b/airsenal/framework/optimization_transfers.py
@@ -21,16 +21,16 @@ from airsenal.framework.utils import (
 
 
 def make_optimum_single_transfer(
-    squad,
-    tag,
-    gameweek_range=None,
-    root_gw=None,
-    season=CURRENT_SEASON,
-    update_func_and_args=None,
-    bench_boost_gw=None,
-    triple_captain_gw=None,
-    verbose=False,
-):
+    squad: Squad,
+    tag: str,
+    gameweek_range: list[int] | None = None,
+    root_gw: int | None = None,
+    season: str = CURRENT_SEASON,
+    update_func_and_args: tuple | None = None,
+    bench_boost_gw: int | None = None,
+    triple_captain_gw: int | None = None,
+    verbose: bool = False,
+) -> tuple[Squad, list[int | str], list[int | str]]:
     """
     If we want to just make one transfer, it's not unfeasible to try all
     possibilities in turn.
@@ -46,7 +46,8 @@ def make_optimum_single_transfer(
 
     best_score = -1.0
     best_squad = None
-    best_pid_out, best_pid_in = [], []
+    best_pid_out: list[int | str] = []
+    best_pid_in: list[int | str] = []
 
     if verbose:
         print("Creating ordered player lists")
@@ -101,16 +102,16 @@ def make_optimum_single_transfer(
 
 
 def make_optimum_double_transfer(
-    squad,
-    tag,
-    gameweek_range=None,
-    root_gw=None,
-    season=CURRENT_SEASON,
-    update_func_and_args=None,
-    bench_boost_gw=None,
-    triple_captain_gw=None,
-    verbose=False,
-):
+    squad: Squad,
+    tag: str,
+    gameweek_range: list[int] | None = None,
+    root_gw: int | None = None,
+    season: str = CURRENT_SEASON,
+    update_func_and_args: tuple | None = None,
+    bench_boost_gw: int | None = None,
+    triple_captain_gw: int | None = None,
+    verbose: bool = False,
+) -> tuple[Squad, list[int | str], list[int | str]]:
     """
     If we want to just make two transfers, it's not infeasible to try all
     possibilities in turn.
@@ -124,7 +125,8 @@ def make_optimum_double_transfer(
     transfer_gw = min(gameweek_range)  # the week we're making the transfer
     best_score = -1.0
     best_squad = None
-    best_pid_out, best_pid_in = [], []
+    best_pid_out: list[int | str] = []
+    best_pid_in: list[int | str] = []
     ordered_player_lists = {
         pos: get_predicted_points(
             gameweek=gameweek_range, position=pos, tag=tag, season=season
@@ -197,17 +199,17 @@ def make_optimum_double_transfer(
 
 
 def make_random_transfers(
-    squad,
-    tag,
-    nsubs=1,
-    gw_range=None,
-    root_gw=None,
-    num_iter=1,
-    update_func_and_args=None,
-    season=CURRENT_SEASON,
-    bench_boost_gw=None,
-    triple_captain_gw=None,
-):
+    squad: Squad,
+    tag: str,
+    nsubs: int = 1,
+    gw_range: list[int] | None = None,
+    root_gw: int | None = None,
+    num_iter: int = 1,
+    update_func_and_args: tuple | None = None,
+    season: str = CURRENT_SEASON,
+    bench_boost_gw: int | None = None,
+    triple_captain_gw: int | None = None,
+) -> tuple[Squad, list[int | str], list[int | str]]:
     """
     choose nsubs random players to sub out, and then select players
     using a triangular PDF to preferentially select the replacements with
@@ -216,7 +218,8 @@ def make_random_transfers(
     """
     best_score = -1.0
     best_squad = None
-    best_pid_out, best_pid_in = [], []
+    best_pid_out: list[int | str] = []
+    best_pid_in: list[int | str] = []
     max_tries = 100
     for _ in range(num_iter):
         if update_func_and_args:
@@ -232,9 +235,9 @@ def make_random_transfers(
 
         transfer_gw = min(gw_range)  # the week we're making the transfer
         players_to_remove: list[int] = []  # this is the index within the squad
-        removed_players: list[int] = []  # this is the player_ids
+        removed_players: list[int | str] = []  # this is the player_ids
         # order the players in the squad by predicted_points - least-to-most
-        player_list: list[tuple[int, float]] = []
+        player_list: list[tuple[int | str, float]] = []
         for p in squad.players:
             p.calc_predicted_points(tag)
             player_list.append((p.player_id, p.predicted_points[tag][gw_range[0]]))
@@ -245,9 +248,9 @@ def make_random_transfers(
                 players_to_remove.append(index)
 
         positions_needed = []
-        for p in players_to_remove:
-            positions_needed.append(squad.players[p].position)
-            removed_players.append(squad.players[p].player_id)
+        for idx in players_to_remove:
+            positions_needed.append(squad.players[idx].position)
+            removed_players.append(squad.players[idx].player_id)
             new_squad.remove_player(removed_players[-1], gameweek=transfer_gw)
         predicted_points = {
             pos: get_predicted_points(
@@ -316,12 +319,12 @@ def make_best_transfers(
     season: str,
     num_iter: int = 100,
     update_func_and_args: tuple[Callable, float, Process] | None = None,
-) -> tuple[Squad, dict[str, list[int]], float]:
+) -> tuple[Squad, dict[str, list[int | str]], float]:
     """
     Return a new squad and a dictionary {"in": [player_ids],
                                         "out":[player_ids]}
     """
-    transfer_dict: dict[str, list[int]] = {}
+    transfer_dict: dict[str, list[int | str]] = {}
     # deal with triple_captain or free_hit
     triple_captain_gw = None
     bench_boost_gw = None
@@ -372,7 +375,7 @@ def make_best_transfers(
 
     elif num_transfers in ["W", "F"]:
         _out = [p.player_id for p in squad.players]
-        budget = squad.sale_value(root_gw, use_api=False)
+        budget = int(squad.sale_value(root_gw, use_api=False))
         if num_transfers == "F":
             gameweeks = [gameweeks[0]]  # for free hit, only need to optimize this week
         new_squad = make_new_squad(

--- a/airsenal/framework/optimization_utils.py
+++ b/airsenal/framework/optimization_utils.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from datetime import datetime
 
 from curl_cffi import requests
+from sqlalchemy.orm.session import Session
 
 from airsenal.framework.schema import (
     Fixture,
@@ -30,7 +31,12 @@ DEFAULT_SUB_WEIGHTS = {"GK": 0.03, "Outfield": (0.65, 0.3, 0.1)}
 MAX_FREE_TRANSFERS = 5  # changed in 24/25 season (not accounted for in replay season)
 
 
-def check_tag_valid(pred_tag, gameweek_range, season=CURRENT_SEASON, dbsession=session):
+def check_tag_valid(
+    pred_tag: str,
+    gameweek_range: list[int],
+    season: str = CURRENT_SEASON,
+    dbsession: Session = session,
+) -> bool:
     """Check a prediction tag contains predictions for all the specified gameweeks."""
     # get unique gameweek and season values associated with pred_tag
     fixtures = (
@@ -51,7 +57,7 @@ def check_tag_valid(pred_tag, gameweek_range, season=CURRENT_SEASON, dbsession=s
     return season_ok and gws_ok
 
 
-def calc_points_hit(num_transfers, free_transfers):
+def calc_points_hit(num_transfers: int | str, free_transfers: int) -> int:
     """
     Current rules say we lose 4 points for every transfer beyond
     the number of free transfers we have.
@@ -76,8 +82,10 @@ def calc_points_hit(num_transfers, free_transfers):
 
 
 def calc_free_transfers(
-    num_transfers, prev_free_transfers, max_free_transfers=MAX_FREE_TRANSFERS
-):
+    num_transfers: int | str,
+    prev_free_transfers: int,
+    max_free_transfers: int = MAX_FREE_TRANSFERS,
+) -> int:
     """
     We get one extra free transfer per week, unless we use a wildcard or
     free hit, but we can't have more than 5.  So we should only be able
@@ -102,12 +110,12 @@ def calc_free_transfers(
 
 
 def get_starting_squad(
-    next_gw=NEXT_GAMEWEEK,
-    season=CURRENT_SEASON,
-    fpl_team_id=None,
-    use_api=False,
+    next_gw: int = NEXT_GAMEWEEK,
+    season: str = CURRENT_SEASON,
+    fpl_team_id: int | None = None,
+    use_api: bool = False,
     apifetcher=fetcher,
-):
+) -> Squad:
     """
     use the transactions table in the db, or the API if requested
     """
@@ -135,7 +143,9 @@ def get_starting_squad(
     return get_squad_from_transactions(next_gw, season, fpl_team_id)
 
 
-def get_squad_from_transactions(gameweek, season=CURRENT_SEASON, fpl_team_id=None):
+def get_squad_from_transactions(
+    gameweek: int, season: str = CURRENT_SEASON, fpl_team_id: int | None = None
+) -> Squad:
     if not fpl_team_id:
         # use the most recent transaction in the table
         most_recent = (
@@ -198,7 +208,7 @@ def get_discounted_squad_score(
     """
     if root_gw is None:
         root_gw = gameweeks[0]
-    total_points = 0
+    total_points = 0.0
     for gw in gameweeks:
         gw_weight = get_discount_factor(root_gw, gw)
         if gw == bench_boost_gw:
@@ -220,31 +230,40 @@ def get_discounted_squad_score(
     return total_points
 
 
-def get_baseline_strat(squad, gameweeks, tag, root_gw=None):
+def get_baseline_strat(
+    squad: Squad, gameweeks: list[int], tag: str, root_gw: int | None = None
+) -> dict:
     """
     Create the strategy dict used by the optimisation for the baseline of making no
     transfers.
     """
-    strat_dict = {
-        "total_score": 0,
-        "points_per_gw": {},
-        "players_in": {},
-        "players_out": {},
-        "chips_played": {},
-        "root_gw": root_gw,
-    }
+    total_score: float = 0
+    points_per_gw: dict[int, float] = {}
+    players_in: dict[int, list] = {}
+    players_out: dict[int, list] = {}
+    chips_played: dict[int, None] = {}
+
     for gw in gameweeks:
         gw_score = get_discounted_squad_score(squad, [gw], tag, root_gw=root_gw)
-        strat_dict["total_score"] += gw_score
-        strat_dict["points_per_gw"][gw] = gw_score
-        strat_dict["players_in"][gw] = []
-        strat_dict["players_out"][gw] = []
-        strat_dict["chips_played"][gw] = None
+        total_score += gw_score
+        points_per_gw[gw] = gw_score
+        players_in[gw] = []
+        players_out[gw] = []
+        chips_played[gw] = None
 
-    return strat_dict
+    return {
+        "total_score": total_score,
+        "points_per_gw": points_per_gw,
+        "players_in": players_in,
+        "players_out": players_out,
+        "chips_played": chips_played,
+        "root_gw": root_gw,
+    }
 
 
-def fill_suggestion_table(baseline_score, best_strat, season, fpl_team_id):
+def fill_suggestion_table(
+    baseline_score: float, best_strat: dict, season: str, fpl_team_id: int
+) -> None:
     """
     Fill the optimized strategy into the table
     """
@@ -269,8 +288,13 @@ def fill_suggestion_table(baseline_score, best_strat, season, fpl_team_id):
 
 
 def fill_transaction_table(
-    starting_squad, best_strat, season, fpl_team_id, tag=None, dbsession=session
-):
+    starting_squad: Squad,
+    best_strat: dict,
+    season: str,
+    fpl_team_id: int,
+    tag: str | None = None,
+    dbsession: Session = session,
+) -> None:
     """Add transactions from an optimised strategy to the transactions table in the
     database. Used for simulating seasons only, for playing the current FPL season
     the transactions status is kept up to date with transfers using the FPL API.
@@ -302,12 +326,15 @@ def fill_transaction_table(
         )
     for player_id in best_strat["players_in"][str(fill_gw)]:
         if player := get_player(player_id, dbsession=dbsession):
-            price = player.price(season, fill_gw)
+            price_in: int | None = player.price(season, fill_gw)
+            if price_in is None:
+                print(f"No price found for player {player_id} in gw {fill_gw}")
+                continue
             add_transaction(
                 player_id,
                 fill_gw,
                 1,
-                price,
+                price_in,
                 season,
                 tag,
                 free_hit,
@@ -320,13 +347,13 @@ def fill_transaction_table(
 
 
 def fill_initial_suggestion_table(
-    squad,
-    fpl_team_id,
-    tag,
-    season=CURRENT_SEASON,
-    gameweek=NEXT_GAMEWEEK,
-    dbsession=session,
-):
+    squad: Squad,
+    fpl_team_id: int,
+    tag: str,
+    season: str = CURRENT_SEASON,
+    gameweek: int = NEXT_GAMEWEEK,
+    dbsession: Session = session,
+) -> None:
     """
     Fill an initial squad into the table
     """
@@ -334,7 +361,7 @@ def fill_initial_suggestion_table(
     score = squad.get_expected_points(gameweek, tag)
     for player in squad.players:
         ts = TransferSuggestion()
-        ts.player_id = player.player_id
+        ts.player_id = player.player_id  # type: ignore[assignment]
         ts.in_or_out = 1
         ts.gameweek = NEXT_GAMEWEEK
         ts.points_gain = score
@@ -347,13 +374,13 @@ def fill_initial_suggestion_table(
 
 
 def fill_initial_transaction_table(
-    squad,
-    fpl_team_id,
-    tag,
-    season=CURRENT_SEASON,
-    gameweek=NEXT_GAMEWEEK,
-    dbsession=session,
-):
+    squad: Squad,
+    fpl_team_id: int,
+    tag: str,
+    season: str = CURRENT_SEASON,
+    gameweek: int = NEXT_GAMEWEEK,
+    dbsession: Session = session,
+) -> None:
     """Add transactions from an initial squad optimisation to the transactions table
     in the database. Used for simulating seasons only, for playing the current FPL
     season the transactions status is kepts up to date with transfers using the FPL API.
@@ -362,7 +389,7 @@ def fill_initial_transaction_table(
     time = datetime.now().isoformat()
     for player in squad.players:
         add_transaction(
-            player.player_id,
+            player.player_id,  # type: ignore[arg-type]
             gameweek,
             1,
             player.purchase_price,
@@ -375,7 +402,7 @@ def fill_initial_transaction_table(
         )
 
 
-def strategy_involves_N_or_more_transfers_in_gw(strategy, N):
+def strategy_involves_N_or_more_transfers_in_gw(strategy: tuple, N: int) -> bool:
     """
     Quick function to see if we need to do multiple iterations
     for a strategy, or if the result is deterministic
@@ -385,7 +412,7 @@ def strategy_involves_N_or_more_transfers_in_gw(strategy, N):
     return any(isinstance(v, int) and v >= N for v in strat_dict.values())
 
 
-def make_strategy_id(strategy):
+def make_strategy_id(strategy: tuple) -> str:
     """
     Return a string that will identify a strategy - just concatenate
     the numbers of transfers per gameweek.
@@ -393,7 +420,7 @@ def make_strategy_id(strategy):
     return ",".join(str(nt) for nt in strategy[0].values())
 
 
-def get_num_increments(num_transfers, num_iterations=100):
+def get_num_increments(num_transfers: int | str, num_iterations: int = 100) -> int:
     """
     how many steps for the progress bar for this strategy
     """
@@ -426,13 +453,13 @@ def get_num_increments(num_transfers, num_iterations=100):
 
 
 def next_week_transfers(
-    strat,
-    max_total_hit=None,
-    allow_unused_transfers=True,
-    max_opt_transfers=2,
-    chips=None,
-    max_free_transfers=MAX_FREE_TRANSFERS,
-):
+    strat: tuple,
+    max_total_hit: int | None = None,
+    allow_unused_transfers: bool = True,
+    max_opt_transfers: int = 2,
+    chips: dict | None = None,
+    max_free_transfers: int = MAX_FREE_TRANSFERS,
+) -> list[tuple]:
     """Given a previous strategy and some optimisation constraints, determine the valid
     options for the number of transfers (or chip played) in the following gameweek.
 
@@ -641,7 +668,12 @@ def count_expected_outputs(
     return len(strategies), baseline_excluded
 
 
-def get_discount_factor(next_gw, pred_gw, discount_type="exp", discount=14 / 15):
+def get_discount_factor(
+    next_gw: int | None,
+    pred_gw: int,
+    discount_type: str = "exp",
+    discount: float = 14 / 15,
+) -> float:
     """
     given the next gw and a predicted gw, retrieve discount factor. Either:
         - exp: discount**n_ahead (discount reduces each gameweek)

--- a/airsenal/framework/player.py
+++ b/airsenal/framework/player.py
@@ -4,6 +4,8 @@ Class for a player in FPL
 
 import uuid
 
+from sqlalchemy.orm.session import Session
+
 from airsenal.framework.schema import Player
 from airsenal.framework.season import CURRENT_SEASON
 from airsenal.framework.utils import (
@@ -20,12 +22,12 @@ class CandidatePlayer:
 
     def __init__(
         self,
-        player,
-        season=CURRENT_SEASON,
-        gameweek=NEXT_GAMEWEEK,
+        player: Player | str | int,
+        season: str = CURRENT_SEASON,
+        gameweek: int = NEXT_GAMEWEEK,
         purchase_price: int | None = None,
-        dbsession=None,
-    ):
+        dbsession: Session | None = None,
+    ) -> None:
         """
         initialize either by name or by ID
         """
@@ -62,12 +64,12 @@ class CandidatePlayer:
         self.is_captain = False
         self.is_vice_captain = False
         self.predicted_points: dict[str, dict[int, float]] = {}
-        self.sub_position = None
+        self.sub_position: int | None = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.display_name or self.name
 
-    def calc_predicted_points(self, tag):
+    def calc_predicted_points(self, tag: str) -> None:
         """
         get expected points from the db.
         Will be a dict of dicts, keyed by tag and gameweeek
@@ -77,7 +79,7 @@ class CandidatePlayer:
                 self.player_id, tag, season=self.season, dbsession=self.dbsession
             )
 
-    def get_predicted_points(self, gameweek, tag):
+    def get_predicted_points(self, gameweek: int, tag: str) -> float:
         """
         get points for a specific gameweek
         """
@@ -94,7 +96,14 @@ class DummyPlayer:
     To fill squads with placeholders for optimisation (if not optimising full squad).
     """
 
-    def __init__(self, gw_range, tag, position, purchase_price=45, pts=0):
+    def __init__(
+        self,
+        gw_range: list[int],
+        tag: str,
+        position: str,
+        purchase_price: int = 45,
+        pts: float = 0,
+    ) -> None:
         self.name = "DUMMY"
         self.display_name = "DUMMY"
         self.position = position
@@ -107,15 +116,15 @@ class DummyPlayer:
         self.is_starting = False
         self.is_captain = False
         self.is_vice_captain = False
-        self.sub_position = None
+        self.sub_position: int | None = None
         self.season = "DUMMY"
 
-    def calc_predicted_points(self, tag):
+    def calc_predicted_points(self, tag: str) -> None:
         """
         Needed for compatibility with Squad/other Player classes
         """
 
-    def get_predicted_points(self, gameweek, tag):  # noqa: ARG002
+    def get_predicted_points(self, gameweek: int, tag: str) -> float:  # noqa: ARG002
         """
         Get points for a specific gameweek -
         """

--- a/airsenal/framework/player_model.py
+++ b/airsenal/framework/player_model.py
@@ -8,13 +8,16 @@ import jax.random as random
 import numpy as np
 import numpyro
 import numpyro.distributions as dist
+import pandas as pd
 from numpyro.infer import MCMC, NUTS
 
 DEFAULT_PLAYER_EPSILON = 0.2
 DEFAULT_N_GOALS_PRIOR = 35
 
 
-def get_empirical_bayes_estimates(df_emp, prior_goals=None):
+def get_empirical_bayes_estimates(
+    df_emp: pd.DataFrame, prior_goals: int | None = None
+) -> np.ndarray:
     """
     Get values to use either for Dirichlet prior alphas in the original Stan and numpyro
     player models. Returns number of goals, assists and neither scaled by the
@@ -56,8 +59,12 @@ def get_empirical_bayes_estimates(df_emp, prior_goals=None):
 
 
 def scale_goals_by_minutes(
-    goals, minutes, time_diff=None, epsilon=None, rescale_weights=True
-):
+    goals: np.ndarray,
+    minutes: np.ndarray,
+    time_diff: np.ndarray | None = None,
+    epsilon: float | None = None,
+    rescale_weights: bool = True,
+) -> np.ndarray:
     """
     Scale player goal involvements by the proportion of minutes they played
     (specifically: reduce the number of "neither" goals where the player is said
@@ -149,9 +156,9 @@ class NumpyroPlayerModel(BasePlayerModel):
     numpyro implementation of the AIrsenal player model.
     """
 
-    def __init__(self):
-        self.player_ids = None
-        self.samples = None
+    def __init__(self) -> None:
+        self.player_ids: np.ndarray | None = None
+        self.samples: dict | None = None
 
     @staticmethod
     def _model(
@@ -185,14 +192,14 @@ class NumpyroPlayerModel(BasePlayerModel):
 
     def fit(
         self,
-        data,
+        data: dict[str, Any],
         random_state: int = 42,
         num_warmup: int = 500,
         num_samples: int = 2000,
         mcmc_kwargs: dict[str, Any] | None = None,
         run_kwargs: dict[str, Any] | None = None,
         **kwargs,
-    ):
+    ) -> NumpyroPlayerModel:
         self.player_ids = data["player_ids"]
         kernel = NUTS(self._model)
         mcmc = MCMC(
@@ -259,16 +266,16 @@ class ConjugatePlayerModel(BasePlayerModel):
     from average goal involvements for all players in that position.
     """
 
-    def __init__(self):
-        self.player_ids = None
-        self.prior = None
-        self.posterior = None
-        self.mean_probabilities = None
+    def __init__(self) -> None:
+        self.player_ids: np.ndarray | None = None
+        self.prior: np.ndarray | None = None
+        self.posterior: np.ndarray | None = None
+        self.mean_probabilities: np.ndarray | None = None
 
         # optional time weighting parameter
-        self.epsilon = None
-        self.time_diff = None
-        self.rescale_weights = None
+        self.epsilon: float | None = None
+        self.time_diff: np.ndarray | None = None
+        self.rescale_weights: bool | None = None
 
     def fit(
         self,

--- a/airsenal/framework/prediction_utils.py
+++ b/airsenal/framework/prediction_utils.py
@@ -61,7 +61,12 @@ np.random.seed(42)
 MAX_GOALS = 10
 
 
-def check_absence(player, gameweek, season, dbsession=session):
+def check_absence(
+    player: Player,
+    gameweek: int,
+    season: str,
+    dbsession: Session = session,
+) -> tuple[str | list[str] | None, str | list[str | None] | None]:
     """
     Query the Absence table for a given player and season to see if the
     gameweek is within the period of absence. If so, return the details of absence.
@@ -75,24 +80,22 @@ def check_absence(player, gameweek, season, dbsession=session):
         .filter(Absence.gw_from < gameweek)
         .filter(Absence.gw_until > gameweek)
     ).all()
-    # save the reasons and details - there may be more than 1 reason for absence
-    reasons = [ab.reason for ab in absence] if len(absence) > 0 else None
-    details = [ab.details for ab in absence] if len(absence) > 0 else None
-    # for those that just have one reason, just take first element of list
-    if reasons is not None:
-        reasons = reasons[0] if len(reasons) == 1 else reasons
-    if details is not None:
-        details = details[0] if len(details) == 1 else details
+    if len(absence) == 0:
+        return None, None
+    if len(absence) == 1:
+        return absence[0].reason, absence[0].details
+    reasons: list[str] = [ab.reason for ab in absence]
+    details: list[str | None] = [ab.details for ab in absence]
     return reasons, details
 
 
 def get_player_history_df(
-    position="all",
-    all_players=False,
-    fill_blank=True,
-    season=CURRENT_SEASON,
-    gameweek=NEXT_GAMEWEEK,
-    dbsession=session,
+    position: str = "all",
+    all_players: bool = False,
+    fill_blank: bool = True,
+    season: str = CURRENT_SEASON,
+    gameweek: int = NEXT_GAMEWEEK,
+    dbsession: Session = session,
 ) -> pd.DataFrame:
     """
     Query the player_score table to get goals/assists/minutes, and then
@@ -169,9 +172,13 @@ def get_player_history_df(
                 team_goals = -1
             expected_goals = row.expected_goals
             expected_assists = row.expected_assists
-            absence_reason, absence_detail = check_absence(
-                player, row.fixture.gameweek, row.fixture.season, session
-            )
+            fixture_gw = row.fixture.gameweek
+            if fixture_gw is None:
+                absence_reason, absence_detail = None, None
+            else:
+                absence_reason, absence_detail = check_absence(
+                    player, fixture_gw, row.fixture.season, session
+                )
             player_data.append(
                 [
                     player.player_id,
@@ -684,8 +691,8 @@ def fit_player_data(
     gameweek: int,
     model: NumpyroPlayerModel | ConjugatePlayerModel | None = None,
     dbsession: Session = session,
-    epsilon=DEFAULT_PLAYER_EPSILON,
-    n_goals_prior=DEFAULT_N_GOALS_PRIOR,
+    epsilon: float | None = DEFAULT_PLAYER_EPSILON,
+    n_goals_prior: int = DEFAULT_N_GOALS_PRIOR,
 ) -> pd.DataFrame:
     """
     Fit the data for a particular position (FWD, MID, DEF).
@@ -711,8 +718,8 @@ def get_all_fitted_player_data(
     gameweek: int,
     model: NumpyroPlayerModel | ConjugatePlayerModel | None = None,
     dbsession: Session = session,
-    epsilon=DEFAULT_PLAYER_EPSILON,
-    n_goals_prior=DEFAULT_N_GOALS_PRIOR,
+    epsilon: float | None = DEFAULT_PLAYER_EPSILON,
+    n_goals_prior: int = DEFAULT_N_GOALS_PRIOR,
 ) -> dict[str, pd.DataFrame]:
     return {
         pos: fit_player_data(

--- a/airsenal/framework/schema.py
+++ b/airsenal/framework/schema.py
@@ -3,6 +3,7 @@ Interface to the SQL database.
 Use SQLAlchemy to convert between DB tables and python objects.
 """
 
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Annotated
 
@@ -10,6 +11,7 @@ from sqlalchemy import ForeignKey, String, create_engine
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
+    Session,
     mapped_column,
     relationship,
     sessionmaker,
@@ -175,7 +177,7 @@ class Player(Base):
             return attr_before
         return attr_after
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.display_name or self.name
 
 
@@ -206,7 +208,7 @@ class PlayerAttributes(Base):
     transfers_in: Mapped[int | None]
     transfers_out: Mapped[int | None]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.player} ({self.season} GW{self.gameweek}): "
             f"£{self.price / 10}, {self.team}, {self.position}"
@@ -228,7 +230,7 @@ class Absence(Base):
     url: Mapped[str100_optional]
     timestamp: Mapped[str100]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"Absence(\n"
             f"  player='{self.player}',\n"
@@ -256,7 +258,7 @@ class Result(Base):
     player: Mapped["Player"] = relationship(back_populates="results")
     player_id: Mapped[int | None] = mapped_column(ForeignKey("player.player_id"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.fixture.season} GW{self.fixture.gameweek} "
             f"{self.fixture.home_team} {self.home_score} - "
@@ -277,7 +279,7 @@ class Fixture(Base):
     tag: Mapped[str100]
     result: Mapped["Result | None"] = relationship(back_populates="fixture")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.season} GW{self.gameweek} {self.home_team} vs. {self.away_team}"
 
 
@@ -326,7 +328,7 @@ class PlayerScore(Base):
     chance_of_playing: Mapped[int | None]
     news: Mapped[str100_optional]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.player} ({self.result}): {self.points} pts, {self.minutes} mins"
 
 
@@ -340,7 +342,7 @@ class PlayerPrediction(Base):
     player: Mapped["Player"] = relationship(back_populates="predictions")
     player_id: Mapped[int | None] = mapped_column(ForeignKey("player.player_id"))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.player}: Predict {self.predicted_points} pts in {self.fixture}"
 
 
@@ -357,7 +359,7 @@ class Transaction(Base):
     free_hit: Mapped[int]  # 1 if transfer on Free Hit, 0 otherwise
     fpl_team_id: Mapped[int]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         trans_str = f"{self.season} GW{self.gameweek}: Team {self.fpl_team_id} "
         if self.bought_or_sold == 1:
             trans_str += f"bought player {self.player_id}"
@@ -380,7 +382,7 @@ class TransferSuggestion(Base):
     fpl_team_id: Mapped[int]  # to identify team to apply transfers.
     chip_played: Mapped[str100_optional]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         sugg_str = f"{self.season} GW{self.gameweek}: Suggest "
         if self.in_or_out == 1:
             sugg_str += f"buying {self.player_id} to gain {self.points_gain:.2f} pts"
@@ -399,7 +401,7 @@ class FifaTeamRating(Base):
     mid: Mapped[int]
     ovr: Mapped[int]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"{self.team} {self.season} FIFA rating: "
             f"ovr {self.ovr}, def {self.defn}, mid {self.mid}, att {self.att}"
@@ -414,7 +416,7 @@ class Team(Base):
     season: Mapped[str4]
     team_id: Mapped[int]  # the season-dependent team ID (from alphabetical order)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.full_name} ({self.name})"
 
 
@@ -460,7 +462,7 @@ def get_connection_string() -> str:
     return f"sqlite:///{AIRSENAL_DB_FILE}"
 
 
-def get_session():
+def get_session() -> Session:
     conn_str = get_connection_string()
     engine = create_engine(conn_str)
 
@@ -478,7 +480,7 @@ session = get_session()
 
 
 @contextmanager
-def session_scope():
+def session_scope() -> Generator[Session]:
     """Provide a transactional scope around a series of operations."""
     session = get_session()
     try:
@@ -491,7 +493,7 @@ def session_scope():
         session.close()
 
 
-def clean_database():
+def clean_database() -> None:
     """
     Clean up database
     """
@@ -500,7 +502,7 @@ def clean_database():
     Base.metadata.create_all(bind=engine)
 
 
-def database_is_empty(dbsession):
+def database_is_empty(dbsession: Session) -> bool:
     """
     Basic check to determine whether the database is empty
     """

--- a/airsenal/framework/season.py
+++ b/airsenal/framework/season.py
@@ -6,10 +6,12 @@ Season details
 
 from datetime import datetime
 
+from sqlalchemy.orm.session import Session
+
 from airsenal.framework.schema import Team, session
 
 
-def get_current_season():
+def get_current_season() -> str:
     """
     use the current time to find what season we're in.
     """
@@ -23,7 +25,7 @@ def get_current_season():
 CURRENT_SEASON = get_current_season()
 
 
-def get_teams_for_season(season, dbsession):
+def get_teams_for_season(season: str, dbsession: Session) -> list[str]:
     """
     Query the Team table and get a list of teams for a given
     season.

--- a/airsenal/framework/squad.py
+++ b/airsenal/framework/squad.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from operator import itemgetter
 
 import numpy as np
+from sqlalchemy.orm.session import Session
 
 from airsenal.framework.data_fetcher import FPLDataFetcher
 from airsenal.framework.player import CandidatePlayer, DummyPlayer
@@ -43,21 +44,21 @@ class Squad:
     Squad class.  Contains 15 players
     """
 
-    def __init__(self, budget=1000, season=CURRENT_SEASON):
+    def __init__(self, budget: float = 1000, season: str = CURRENT_SEASON) -> None:
         """
         constructor - start with an initial empty player list,
         and £100M
         """
-        self.players = []
+        self.players: list[CandidatePlayer | DummyPlayer] = []
         self.budget = budget
         self.season = season
-        self.num_position = {"GK": 0, "DEF": 0, "MID": 0, "FWD": 0}
+        self.num_position: dict[str, int] = {"GK": 0, "DEF": 0, "MID": 0, "FWD": 0}
         self.free_subs = 0
         self.subs_this_week = 0
         self.verbose = False
-        self.count_per_team = defaultdict(int)
+        self.count_per_team: defaultdict[str, int] = defaultdict(int)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Display the squad
         """
@@ -74,12 +75,12 @@ class Squad:
         print("\n=== Subs ===\n")
 
         subs = [p for p in self.players if not p.is_starting]
-        subs.sort(key=lambda p: p.sub_position)
+        subs.sort(key=lambda p: p.sub_position if p.sub_position is not None else 0)
         for p in subs:
             print(f"{p} ({p.team})")
         return ""
 
-    def is_complete(self):
+    def is_complete(self) -> bool:
         """
         See if we have 15 players.
         """
@@ -89,12 +90,12 @@ class Squad:
     def add_player(
         self,
         p: CandidatePlayer | DummyPlayer | int | str | Player,
-        price=None,
-        gameweek=NEXT_GAMEWEEK,
-        check_budget=True,
-        check_team=True,
-        dbsession=None,
-    ):
+        price: int | None = None,
+        gameweek: int = NEXT_GAMEWEEK,
+        check_budget: bool = True,
+        check_team: bool = True,
+        dbsession: "Session | None" = None,
+    ) -> bool:
         """
         Add a player.  Can do it by name or by player_id.
         If no price is specified, CandidatePlayer constructor will use the
@@ -148,12 +149,12 @@ class Squad:
 
     def remove_player(
         self,
-        player_id,
-        price=None,
-        gameweek=NEXT_GAMEWEEK,
-        use_api=False,
-        dbsession=None,
-    ):
+        player_id: int | str,
+        price: int | None = None,
+        gameweek: int = NEXT_GAMEWEEK,
+        use_api: bool = False,
+        dbsession: "Session | None" = None,
+    ) -> bool:
         """
         Remove player from our list.
         If a price is specified, we use that, otherwise we
@@ -178,7 +179,7 @@ class Squad:
                 return True
         return False
 
-    def get_player_from_id(self, player_id):
+    def get_player_from_id(self, player_id: int | str) -> CandidatePlayer | DummyPlayer:
         for p in self.players:
             if p.player_id == player_id:
                 return p
@@ -187,12 +188,12 @@ class Squad:
 
     def get_sell_price_for_player(
         self,
-        player,
-        use_api=False,
-        gameweek=NEXT_GAMEWEEK,
-        dbsession=None,
-        apifetcher=fetcher,
-    ):
+        player: CandidatePlayer | DummyPlayer | int,
+        use_api: bool = False,
+        gameweek: int = NEXT_GAMEWEEK,
+        dbsession: "Session | None" = None,
+        apifetcher: FPLDataFetcher = fetcher,
+    ) -> int:
         """Get sale price for player (a player in self.players) in the current
         gameweek of the current season.
         """
@@ -248,13 +249,13 @@ class Squad:
             return (price_now + price_bought) // 2
         return price_now
 
-    def check_no_duplicate_player(self, player):
+    def check_no_duplicate_player(self, player: CandidatePlayer | DummyPlayer) -> bool:
         """
         Check we don't already have the player.
         """
         return all(p.player_id != player.player_id for p in self.players)
 
-    def check_num_in_position(self, player):
+    def check_num_in_position(self, player: CandidatePlayer | DummyPlayer) -> bool:
         """
         check we have fewer than the limit of
         num players in the chosen players position.
@@ -262,7 +263,7 @@ class Squad:
         position = player.position
         return self.num_position[position] < TOTAL_PER_POSITION[position]
 
-    def check_num_per_team(self, player):
+    def check_num_per_team(self, player: CandidatePlayer | DummyPlayer) -> bool:
         """
         Check that the squad currently has a maximum of 3 players from the same team,
         and that adding the specified player would not exceed this limit.
@@ -272,13 +273,13 @@ class Squad:
             and max(self.count_per_team.values()) < 4
         )
 
-    def check_cost(self, player):
+    def check_cost(self, player: CandidatePlayer | DummyPlayer) -> bool:
         """
         check we can afford the player.
         """
         return player.purchase_price <= self.budget
 
-    def _calc_expected_points(self, tag):
+    def _calc_expected_points(self, tag: str) -> None:
         """
         estimate the expected points for the specified gameweek.
         If no gameweek is specified, it will be the next fixture
@@ -286,13 +287,13 @@ class Squad:
         for p in self.players:
             p.calc_predicted_points(tag)
 
-    def optimize_subs(self, gameweek, tag):
+    def optimize_subs(self, gameweek: int, tag: str) -> float:
         """
         based on pre-calculated expected points,
         choose the best starting 11, obeying constraints.
         """
         # first order all the players by expected points
-        player_dict: dict[str, list[tuple[CandidatePlayer, float]]] = {
+        player_dict: dict[str, list[tuple[CandidatePlayer | DummyPlayer, float]]] = {
             "GK": [],
             "DEF": [],
             "MID": [],
@@ -322,12 +323,13 @@ class Squad:
                 best_formation = f
         if self.verbose:
             print(f"Best formation is {best_formation}")
+        assert best_formation is not None
         self.apply_formation(player_dict, best_formation)
         self.order_substitutes(gameweek, tag)
 
         return best_score
 
-    def order_substitutes(self, gameweek, tag):
+    def order_substitutes(self, gameweek: int, tag: str) -> None:
         # order substitutes by expected points (descending)
         subs = [p for p in self.players if not p.is_starting]
 
@@ -343,7 +345,11 @@ class Squad:
         for sub_position, sub_ind in enumerate(ordered_sub_inds):
             subs[sub_ind].sub_position = sub_position
 
-    def apply_formation(self, player_dict, formation):
+    def apply_formation(
+        self,
+        player_dict: dict[str, list[tuple[CandidatePlayer | DummyPlayer, float]]],
+        formation: tuple[int, int, int],
+    ) -> None:
         """
         set players' is_starting to True or False
         depending on specified formation in format e.g.
@@ -353,18 +359,22 @@ class Squad:
             for index, player in enumerate(player_dict[pos]):
                 player[0].is_starting = index < formation[i]
 
-    def get_formation(self):
+    def get_formation(self) -> dict[str, int]:
         """
         Return the formation of a starting 11 in the form
         of a dict {"DEF": nDEF, "MID": nMID, "FWD": nFWD}
         """
-        formation = {"GK": 0, "DEF": 0, "MID": 0, "FWD": 0}
+        formation: dict[str, int] = {"GK": 0, "DEF": 0, "MID": 0, "FWD": 0}
         for player in self.players:
             if player.is_starting:
                 formation[player.position] += 1
         return formation
 
-    def is_substitution_allowed(self, player_out, player_in):
+    def is_substitution_allowed(
+        self,
+        player_out: CandidatePlayer | DummyPlayer,
+        player_in: CandidatePlayer | DummyPlayer,
+    ) -> bool:
         """
         for a given player out and player in, would the substitution result in a
         valid formation?
@@ -399,7 +409,10 @@ class Squad:
         outfield_subs = [
             p for p in self.players if (not p.is_starting) and (p.position != "GK")
         ]
-        outfield_subs = sorted(outfield_subs, key=lambda p: p.sub_position)
+        outfield_subs = sorted(
+            outfield_subs,
+            key=lambda p: p.sub_position if p.sub_position is not None else 0,
+        )
 
         gk_sub = next(
             p for p in self.players if (not p.is_starting) and (p.position == "GK")
@@ -412,7 +425,7 @@ class Squad:
 
         return total
 
-    def optimize_lineup(self, gameweek: int, tag: str):
+    def optimize_lineup(self, gameweek: int, tag: str) -> None:
         if not self.is_complete():
             msg = "Squad is incomplete"
             raise RuntimeError(msg)
@@ -422,8 +435,12 @@ class Squad:
         self.pick_captains(gameweek, tag)
 
     def get_expected_points(
-        self, gameweek, tag, bench_boost=False, triple_captain=False
-    ):
+        self,
+        gameweek: int,
+        tag: str,
+        bench_boost: bool = False,
+        triple_captain: bool = False,
+    ) -> float:
         """
         expected points for the starting 11.
         """
@@ -439,7 +456,7 @@ class Squad:
 
         return total_score
 
-    def pick_captains(self, gameweek, tag):
+    def pick_captains(self, gameweek: int, tag: str) -> None:
         """
         pick the highest two expected points for captain and vice-captain
         """
@@ -454,8 +471,12 @@ class Squad:
         player_list[1][0].is_vice_captain = True
 
     def get_actual_points(
-        self, gameweek, season, triple_captain=False, bench_boost=False
-    ):
+        self,
+        gameweek: int,
+        season: str,
+        triple_captain: bool = False,
+        bench_boost: bool = False,
+    ) -> int:
         """
         Calculate the actual points a squad stored in a historical gameweek/season.
         """
@@ -469,11 +490,11 @@ class Squad:
         vice_captain_points = 0
 
         # this will be used to make an ordered list of subs
-        subs: list[tuple[int, Player]] = []
+        subs: list[tuple[int | None, CandidatePlayer | DummyPlayer]] = []
         need_sub = []
         for p in self.players:
             if p.is_starting or bench_boost:
-                scores = get_playerscores_for_player_gameweek(p, gameweek, season)
+                scores = get_playerscores_for_player_gameweek(p, gameweek, season)  # type: ignore[arg-type]
                 minutes = sum(s.minutes for s in scores)
                 if minutes > 0:
                     for score in scores:
@@ -495,7 +516,9 @@ class Squad:
                 # put the subs in order
                 subs.append((p.sub_position, p))
 
-        ordered_subs = [s[1] for s in sorted(subs, key=itemgetter(0))]
+        ordered_subs = [
+            s[1] for s in sorted(subs, key=lambda x: x[0] if x[0] is not None else 0)
+        ]
 
         # now take account of possibility that captain didn't play
         if need_vice_captain:
@@ -510,7 +533,9 @@ class Squad:
                     if not self.is_substitution_allowed(p_out, p_in):
                         continue
                     scores = get_playerscores_for_player_gameweek(
-                        p_in, gameweek, season
+                        p_in,  # type: ignore[arg-type]
+                        gameweek,
+                        season,
                     )
                     minutes = sum(s.minutes for s in scores)
                     if minutes > 0:
@@ -520,7 +545,7 @@ class Squad:
                         break
         return total_points
 
-    def sale_value(self, gameweek: int, use_api: bool) -> int:
+    def sale_value(self, gameweek: int, use_api: bool) -> float:
         total_value = self.budget  # initialise total to amount in the bank
         for p in self.players:
             total_value += self.get_sell_price_for_player(

--- a/airsenal/framework/transaction_utils.py
+++ b/airsenal/framework/transaction_utils.py
@@ -5,6 +5,7 @@ variable, or a file named FPL_TEAM_ID in airsenal/data/
 """
 
 from sqlalchemy import and_, or_
+from sqlalchemy.orm.session import Session
 
 from airsenal.framework.schema import Transaction
 from airsenal.framework.utils import (
@@ -18,7 +19,7 @@ from airsenal.framework.utils import (
 )
 
 
-def free_hit_used_in_gameweek(gameweek, fpl_team_id=None):
+def free_hit_used_in_gameweek(gameweek: int, fpl_team_id: int | None = None) -> int:
     """Use FPL API to determine whether a chip was played in the given gameweek"""
     if not fpl_team_id:
         fpl_team_id = fetcher.FPL_TEAM_ID
@@ -32,7 +33,9 @@ def free_hit_used_in_gameweek(gameweek, fpl_team_id=None):
     return 0
 
 
-def count_transactions(season, fpl_team_id, dbsession=session):
+def count_transactions(
+    season: str, fpl_team_id: int | None, dbsession: Session = session
+) -> int:
     """Count the number of transactions we have in the database for a given team ID
     and season.
     """
@@ -49,16 +52,16 @@ def count_transactions(season, fpl_team_id, dbsession=session):
 
 
 def transaction_exists(
-    fpl_team_id,
-    gameweek,
-    season,
-    time,
-    pid_out,
-    price_out,
-    pid_in,
-    price_in,
-    dbsession=session,
-):
+    fpl_team_id: int,
+    gameweek: int,
+    season: str,
+    time: str,
+    pid_out: int,
+    price_out: int,
+    pid_in: int,
+    price_in: int,
+    dbsession: Session = session,
+) -> bool:
     """Check whether the transactions related to transferring a player in and out
     in a gameweek at a specific time already exist in the database.
     """
@@ -97,17 +100,17 @@ def transaction_exists(
 
 
 def add_transaction(
-    player_id,
-    gameweek,
-    in_or_out,
-    price,
-    season,
-    tag,
-    free_hit,
-    fpl_team_id,
-    time,
-    dbsession=session,
-):
+    player_id: int,
+    gameweek: int,
+    in_or_out: int,
+    price: int,
+    season: str,
+    tag: str,
+    free_hit: int,
+    fpl_team_id: int,
+    time: str,
+    dbsession: Session = session,
+) -> None:
     """
     add buy (in_or_out=1) or sell (in_or_out=-1) transactions to the db table.
     """
@@ -127,19 +130,22 @@ def add_transaction(
 
 
 def fill_initial_squad(
-    season=CURRENT_SEASON,
-    tag="AIrsenal" + CURRENT_SEASON,
-    fpl_team_id=None,
-    dbsession=session,
-):
+    season: str = CURRENT_SEASON,
+    tag: str = "AIrsenal" + CURRENT_SEASON,
+    fpl_team_id: int | None = None,
+    dbsession: Session = session,
+) -> None:
     """
     Fill the Transactions table in the database with the initial 15 players, and their
     costs, getting the information from the team history API endpoint (for the list of
     players in our team) and the player history API endpoint (for their price in gw1).
     """
 
-    if not fpl_team_id:
+    if fpl_team_id is None:
         fpl_team_id = fetcher.FPL_TEAM_ID
+    if fpl_team_id is None:
+        msg = "fpl_team_id must be provided or set in environment"
+        raise ValueError(msg)
     print(
         "Getting initially selected players "
         f"in squad {fpl_team_id} for first gameweek..."
@@ -164,6 +170,9 @@ def fill_initial_squad(
     time = fetcher.get_event_data()[starting_gw]["deadline"]
     for player in init_players:
         player_api_id = player.fpl_api_id
+        if player_api_id is None:
+            print(f"Skipping player with no fpl_api_id: {player}")
+            continue
         first_gw_data = fetcher.get_gameweek_data_for_player(player_api_id, starting_gw)
 
         if len(first_gw_data) == 0:
@@ -196,18 +205,21 @@ def fill_initial_squad(
 
 
 def update_squad(
-    season=CURRENT_SEASON,
-    tag="AIrsenal" + CURRENT_SEASON,
-    fpl_team_id=None,
-    dbsession=session,
-    verbose=True,
-):
+    season: str = CURRENT_SEASON,
+    tag: str = "AIrsenal" + CURRENT_SEASON,
+    fpl_team_id: int | None = None,
+    dbsession: Session = session,
+    verbose: bool = True,
+) -> None:
     """
     Fill the Transactions table in the DB with all the transfers in gameweeks after 1,
     using the transfers API endpoint which has the correct buy and sell prices.
     """
-    if not fpl_team_id:
+    if fpl_team_id is None:
         fpl_team_id = fetcher.FPL_TEAM_ID
+    if fpl_team_id is None:
+        msg = "fpl_team_id must be provided or set in environment"
+        raise ValueError(msg)
     print(f"Updating db with squad with fpl_team_id={fpl_team_id}")
     # do we already have the initial squad for this fpl_team_id?
     existing_transfers = (

--- a/airsenal/framework/utils.py
+++ b/airsenal/framework/utils.py
@@ -407,8 +407,11 @@ def get_free_transfers(
     """
     if season == CURRENT_SEASON and not is_replay:
         # we will use the API to estimate num transfers
-        if not fpl_team_id:
+        if fpl_team_id is None:
             fpl_team_id = apifetcher.FPL_TEAM_ID
+        if fpl_team_id is None:
+            msg = "fpl_team_id must be provided or set in environment"
+            raise ValueError(msg)
 
         # try to get the most up-to-date info from logged in api
         try:
@@ -711,8 +714,8 @@ def list_players(
             zip(prices, players, strict=False), reverse=True, key=lambda p: p[0]
         )
         if verbose:
-            for pa in sort_players:
-                print(pa[1], pa[0])
+            for price_pa, player_pa in sort_players:
+                print(player_pa, price_pa)
         players = [p for _, p in sort_players]
     return players
 

--- a/airsenal/scripts/fill_transfersuggestion_table.py
+++ b/airsenal/scripts/fill_transfersuggestion_table.py
@@ -616,6 +616,11 @@ def run_optimization(
     best_strategy = find_best_strat_from_json(tag)
 
     baseline_score = find_baseline_score_from_json(tag, num_weeks)
+
+    if best_strategy is None:
+        msg = "Failed to find a strategy!"
+        raise ValueError(msg)
+
     fill_suggestion_table(baseline_score, best_strategy, season, fpl_team_id)
     if is_replay:
         # simulating a previous season, so imitate applying transfers by adding
@@ -624,10 +629,6 @@ def run_optimization(
 
     for _ in range(len(procs)):
         print("\n")
-
-    if best_strategy is None:
-        msg = "Failed to find a strategy!"
-        raise ValueError(msg)
 
     print("================")
     print("OPTIMUM STRATEGY")
@@ -657,21 +658,25 @@ def run_optimization(
             ]
             for position in ["GK", "DEF", "MID", "FWD"]:
                 lineup_strings.append(f"== **{position}** ==\n```")
-                for p in best_squad.players:
-                    if p.position == position and p.is_starting:
-                        player_line = f"{p} ({p.team})"
-                        if p.is_captain:
+                for player in best_squad.players:
+                    if player.position == position and player.is_starting:
+                        player_line = f"{player} ({player.team})"
+                        if player.is_captain:
                             player_line += "(C)"
-                        elif p.is_vice_captain:
+                        elif player.is_vice_captain:
                             player_line += "(VC)"
                         lineup_strings.append(player_line)
                 lineup_strings.append("```\n")
             lineup_strings.append("__subs__")
             lineup_strings.append("```")
-            subs = [p for p in best_squad.players if not p.is_starting]
-            subs.sort(key=lambda p: p.sub_position)
-            for p in subs:
-                lineup_strings.append(f"{p} ({p.team})")
+            subs = [player for player in best_squad.players if not player.is_starting]
+            subs.sort(
+                key=lambda player: player.sub_position
+                if player.sub_position is not None
+                else 0
+            )
+            for player in subs:
+                lineup_strings.append(f"{player} ({player.team})")
             lineup_strings.append("```\n")
 
             # generate a discord embed json and send to webhook

--- a/airsenal/scripts/save_expected_absences.py
+++ b/airsenal/scripts/save_expected_absences.py
@@ -59,7 +59,6 @@ def player_attribute_to_absence(player_attribute):
     a.season = player_attribute.season
     a.gw_from = player_attribute.gameweek
     a.gw_until = player_attribute.return_gameweek
-    a.chance_of_playing = player_attribute.chance_of_playing_next_round
     a.reason = player_attribute.news
     a.timestamp = datetime.datetime.now().isoformat()
 

--- a/airsenal/scripts/scrape_transfermarkt.py
+++ b/airsenal/scripts/scrape_transfermarkt.py
@@ -91,10 +91,10 @@ def get_team_players(team_season_url: str) -> list[tuple[str, str]]:
     player_names_urls = []
     for r in player_rows:
         if not isinstance(r, Tag):
-            continue
+            continue  # type: ignore[unreachable]
         last_a_tag = r.find_all("a")[-1]
         if not isinstance(last_a_tag, Tag):
-            continue
+            continue  # type: ignore[unreachable]
         name = str(last_a_tag.contents[0]).strip()
         url = str(last_a_tag.get("href"))
         player_names_urls.append((name, url))
@@ -230,18 +230,18 @@ def get_player_suspensions(
 
     table = player_soup.find_all("table")[0]
     if not isinstance(table, Tag):
-        print("Could not find table with suspensions/absences")
+        print("Could not find table with suspensions/absences")  # type: ignore[unreachable]
         return pd.DataFrame()
     rows = table.find_all("tr")[1:]  # skip header row
     comp = []
     for row in rows:
         if not isinstance(row, Tag):
-            print("Skipping row that is not a Tag")
+            print("Skipping row that is not a Tag")  # type: ignore[unreachable]
             continue
         try:
             img = row.find_all("img")[0]
             if not isinstance(img, Tag):
-                msg = "Image tag not found"
+                msg = "Image tag not found"  # type: ignore[unreachable]
                 raise IndexError(msg)
             comp.append(img.get("title"))
         except IndexError:
@@ -364,7 +364,7 @@ def get_player_transfers(
             i
         ]
         if not isinstance(old, Tag):
-            print(f"Old club details is unexpected type {type(old)}")
+            print(f"Old club details is unexpected type {type(old)}")  # type: ignore[unreachable]
             continue
         old_club = " ".join(old.getText().split())
         if old.a is None:
@@ -380,7 +380,7 @@ def get_player_transfers(
             i
         ]
         if not isinstance(new, Tag):
-            print(f"New club details is unexpected type {type(new)}")
+            print(f"New club details is unexpected type {type(new)}")  # type: ignore[unreachable]
             continue
         new_club = " ".join(new.getText().split())
         if new.a is None:

--- a/airsenal/scripts/set_lineup.py
+++ b/airsenal/scripts/set_lineup.py
@@ -54,11 +54,13 @@ def build_lineup_payload(squad: Squad) -> list:
     payload.append(to_dict(sub_gk, 12))
 
     available_sub_positions = list(range(4))
+    assert sub_gk.sub_position is not None, "sub_gk has no sub_position"
     available_sub_positions.remove(sub_gk.sub_position)
     subs_outfield = [
         p for p in squad.players if not p.is_starting and p.position != "GK"
     ]
     for s in subs_outfield:
+        assert s.sub_position is not None, f"outfield sub {s} has no sub_position"
         payload.append(to_dict(s, 13 + available_sub_positions.index(s.sub_position)))
 
     return payload

--- a/airsenal/scripts/squad_builder.py
+++ b/airsenal/scripts/squad_builder.py
@@ -56,13 +56,6 @@ def fill_initial_squad(
         verbose=verbose,
     )
 
-    if best_squad is None:
-        msg = (
-            "best_squad is None: make_new_squad failed to generate a valid team or "
-            "something went wrong with the squad expected points calculation."
-        )
-        raise RuntimeError(msg)
-
     gw_start = gw_range[0]
     optimised_score = get_discounted_squad_score(
         best_squad,
@@ -208,7 +201,11 @@ def main():
     mutation_indpb = args.mutation_indpb
     tournament_size = args.tournament_size
     remove_zero = not args.include_zero
-    fpl_team_id = args.fpl_team_id or fetcher.FPL_TEAM_ID
+    _fpl_team_id = args.fpl_team_id or fetcher.FPL_TEAM_ID
+    if _fpl_team_id is None:
+        msg = "fpl_team_id must be provided via --fpl_team_id or FPL_TEAM_ID env var"
+        raise ValueError(msg)
+    fpl_team_id: int = _fpl_team_id
     if args.no_subs:
         sub_weights = {"GK": 0, "Outfield": (0, 0, 0)}
     else:


### PR DESCRIPTION
## Summary

- Adds complete Python type annotations to all functions in `airsenal/framework/` and `airsenal/scripts/`
- All 63 source files checked by mypy with 0 errors (`uv run mypy airsenal/framework airsenal/scripts`)
- All 92 tests pass (`uv run pytest airsenal/tests`, excluding pre-existing `test_api_utils.py` which requires optional `flask` dependency)

## Key changes

- **Type annotations**: Return types, parameter types, and variable annotations added throughout all framework and script modules
- **`data_fetcher.py`**: Replaced `cast()` calls with `_get_dict_request()`/`_get_list_request()` helpers using `assert isinstance()` for runtime safety; added `@overload` for `get_gameweek_data_for_player()` return type dispatch
- **`api_utils.py`**: Removed incorrect `scoped_session` wrapper; fixed `dbsession.remove()` → `dbsession.close()`
- **`squad.py`**: Fixed `None`-in-sort-key patterns, widened player dict types for `DummyPlayer` support
- **`player.py`**: Added `sub_position: int | None` annotation so mypy can narrow correctly
- **`optimization_transfers.py`**: Widened `player_id` types to `int | str` to accommodate `DummyPlayer`; fixed loop variable shadowing
- **`scrape_transfermarkt.py`**: Added `# type: ignore[unreachable]` for bs4 `isinstance` guards (stubs type `find_all` results as always `Tag`)
- **`save_expected_absences.py`**: Removed assignment to non-existent `Absence.chance_of_playing` attribute
- **`env.py`**: Fixed import ordering (E402)
- Various None-narrowing fixes using `if x is None:` instead of `if not x:` patterns

## Test plan

- [x] `uv run mypy airsenal/framework airsenal/scripts` → `Success: no issues found in 63 source files`
- [x] `uv run pytest airsenal/tests --ignore=airsenal/tests/test_api_utils.py` → `92 passed, 1 skipped, 1 xfailed`
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)